### PR TITLE
Release for 0.1.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.38](https://github.com/baryhuang/claude-code-by-agents/compare/0.1.37...0.1.38) - 2025-08-02
+
 ## [0.1.37](https://github.com/baryhuang/claude-code-by-agents/compare/v0.0.4...0.1.37) - 2025-08-02
 - Add Claude Code GitHub Workflow by @baryhuang in https://github.com/baryhuang/claude-code-by-agents/pull/14
 - Release for 0.1.37 by @github-actions[bot] in https://github.com/baryhuang/claude-code-by-agents/pull/15

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentrooms",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "type": "module",
   "description": "Agentrooms - Multi-agent workspace for collaborative development",
   "keywords": [


### PR DESCRIPTION
This pull request is for the next release as 0.1.38 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag 0.1.38 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-0.1.37" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->



**Full Changelog**: https://github.com/baryhuang/claude-code-by-agents/compare/0.1.37...0.1.38