### PR TITLE
Release v0.0.5 - Fix binary naming to use Agentrooms prefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentrooms",
   "productName": "Agentrooms",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Multi-Agent Programming Collaboration Tool",
   "main": "electron/main.js",
   "scripts": {


### PR DESCRIPTION
Fixes #26 - Updates binary naming from "claude-code-webui-" to "Agentrooms" prefix.

This release will generate properly named binaries:
- macOS: `Agentrooms-0.0.5.dmg`
- Windows: `Agentrooms Setup 0.0.5.exe`
- Linux: `Agentrooms-0.0.5.AppImage`

Generated with [Claude Code](https://claude.ai/code)