### PR TITLE
feat: Add comprehensive Swagger API documentation

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -23,6 +23,7 @@ import { handleAgentHistoriesRequest } from "./handlers/agentHistories.ts";
 import { handleAgentConversationRequest } from "./handlers/agentConversations.ts";
 import { globalRegistry } from "./providers/registry.ts";
 import { globalImageHandler } from "./utils/imageHandling.ts";
+import { specs } from "./swagger/config.ts";
 
 export interface AppConfig {
   debugMode: boolean;
@@ -64,7 +65,21 @@ export function createApp(
   );
 
   // API routes
-  // Health check endpoint
+  /**
+   * @swagger
+   * /api/health:
+   *   get:
+   *     summary: Health check endpoint
+   *     description: Returns the current status and basic information about the Agentrooms service
+   *     tags: [Health]
+   *     responses:
+   *       200:
+   *         description: Service is healthy and operational
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/HealthResponse'
+   */
   app.get("/api/health", (c) => {
     return c.json({
       status: "ok",
@@ -74,35 +89,445 @@ export function createApp(
     });
   });
 
+  /**
+   * @swagger
+   * /api/projects:
+   *   get:
+   *     summary: List available local project directories
+   *     description: Retrieves list of available project directories from Claude configuration that have conversation history
+   *     tags: [Projects]
+   *     responses:
+   *       200:
+   *         description: List of projects with history
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ProjectsResponse'
+   *       500:
+   *         description: Server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   */
   app.get("/api/projects", (c) => handleProjectsRequest(c));
 
+  /**
+   * @swagger
+   * /api/projects/{encodedProjectName}/histories:
+   *   get:
+   *     summary: Get conversation summaries for a local project
+   *     description: Retrieves list of conversation summaries for a specific local project
+   *     tags: [History]
+   *     parameters:
+   *       - in: path
+   *         name: encodedProjectName
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: URL-encoded project name
+   *     responses:
+   *       200:
+   *         description: List of conversation summaries
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/HistoryListResponse'
+   *       404:
+   *         description: Project not found
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       500:
+   *         description: Server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   */
   app.get("/api/projects/:encodedProjectName/histories", (c) =>
     handleHistoriesRequest(c),
   );
 
+  /**
+   * @swagger
+   * /api/projects/{encodedProjectName}/histories/{sessionId}:
+   *   get:
+   *     summary: Get full conversation details for a local project
+   *     description: Retrieves complete conversation history including all messages for a specific session
+   *     tags: [History]
+   *     parameters:
+   *       - in: path
+   *         name: encodedProjectName
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: URL-encoded project name
+   *       - in: path
+   *         name: sessionId
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Unique session identifier
+   *     responses:
+   *       200:
+   *         description: Complete conversation history
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ConversationHistory'
+   *       404:
+   *         description: Project or session not found
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       500:
+   *         description: Server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   */
   app.get("/api/projects/:encodedProjectName/histories/:sessionId", (c) =>
     handleConversationRequest(c),
   );
 
   // Agent history endpoints
+  /**
+   * @swagger
+   * /api/agent-projects:
+   *   get:
+   *     summary: Get remote agent's available projects
+   *     description: Retrieves list of available project directories from a remote agent's Claude configuration
+   *     tags: [Agent Management]
+   *     responses:
+   *       200:
+   *         description: List of remote agent's projects
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ProjectsResponse'
+   *       500:
+   *         description: Server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   */
   app.get("/api/agent-projects", (c) => handleAgentProjectsRequest(c));
   
+  /**
+   * @swagger
+   * /api/agent-histories/{encodedProjectName}:
+   *   get:
+   *     summary: Get conversation summaries for a remote agent's project
+   *     description: Retrieves list of conversation summaries from a remote agent for a specific project
+   *     tags: [Agent Management]
+   *     parameters:
+   *       - in: path
+   *         name: encodedProjectName
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: URL-encoded project name
+   *     responses:
+   *       200:
+   *         description: List of conversation summaries from remote agent
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/HistoryListResponse'
+   *       404:
+   *         description: Project not found on remote agent
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       500:
+   *         description: Server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   */
   app.get("/api/agent-histories/:encodedProjectName", (c) =>
     handleAgentHistoriesRequest(c),
   );
   
+  /**
+   * @swagger
+   * /api/agent-conversations/{encodedProjectName}/{sessionId}:
+   *   get:
+   *     summary: Get full conversation details from a remote agent
+   *     description: Retrieves complete conversation history from a remote agent including all messages for a specific session
+   *     tags: [Agent Management]
+   *     parameters:
+   *       - in: path
+   *         name: encodedProjectName
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: URL-encoded project name
+   *       - in: path
+   *         name: sessionId
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Unique session identifier
+   *     responses:
+   *       200:
+   *         description: Complete conversation history from remote agent
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ConversationHistory'
+   *       404:
+   *         description: Project or session not found on remote agent
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       500:
+   *         description: Server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   */
   app.get("/api/agent-conversations/:encodedProjectName/:sessionId", (c) =>
     handleAgentConversationRequest(c),
   );
 
+  /**
+   * @swagger
+   * /api/abort/{requestId}:
+   *   post:
+   *     summary: Abort ongoing chat request
+   *     description: Cancels a running chat request using its unique request ID
+   *     tags: [Chat]
+   *     parameters:
+   *       - in: path
+   *         name: requestId
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Unique request identifier to abort
+   *     responses:
+   *       200:
+   *         description: Request aborted successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 message:
+   *                   type: string
+   *                   example: "Request aborted"
+   *       404:
+   *         description: Request ID not found or already completed
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   */
   app.post("/api/abort/:requestId", (c) =>
     handleAbortRequest(c, requestAbortControllers),
   );
 
+  /**
+   * @swagger
+   * /api/chat:
+   *   post:
+   *     summary: Main chat endpoint for Claude Code SDK integration
+   *     description: Sends a message to Claude Code SDK or routes to specific agents. Returns streaming NDJSON responses.
+   *     tags: [Chat]
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             $ref: '#/components/schemas/ChatRequest'
+   *           examples:
+   *             simple_chat:
+   *               summary: Simple chat message
+   *               value:
+   *                 message: "Help me write a function to validate email addresses"
+   *                 requestId: "req-123"
+   *             with_session:
+   *               summary: Chat with session continuity
+   *               value:
+   *                 message: "Can you also add error handling to that function?"
+   *                 sessionId: "session-456"
+   *                 requestId: "req-124"
+   *             with_tools:
+   *               summary: Chat with specific tools allowed
+   *               value:
+   *                 message: "Read the package.json file and tell me the dependencies"
+   *                 requestId: "req-125"
+   *                 allowedTools: ["Read", "Glob"]
+   *                 workingDirectory: "/path/to/project"
+   *     responses:
+   *       200:
+   *         description: Streaming NDJSON response from Claude Code SDK
+   *         content:
+   *           application/x-ndjson:
+   *             schema:
+   *               $ref: '#/components/schemas/StreamResponse'
+   *       400:
+   *         description: Invalid request format
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       500:
+   *         description: Server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   */
   app.post("/api/chat", (c) => handleChatRequest(c, requestAbortControllers));
   
-  // Multi-agent chat endpoint
+  /**
+   * @swagger
+   * /api/multi-agent-chat:
+   *   post:
+   *     summary: Multi-agent chat endpoint
+   *     description: Handles orchestrated conversations between multiple remote agents
+   *     tags: [Chat]
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             $ref: '#/components/schemas/ChatRequest'
+   *           examples:
+   *             orchestrator_request:
+   *               summary: Multi-agent orchestration request
+   *               value:
+   *                 message: "Create a user authentication system with frontend and backend components"
+   *                 requestId: "req-orchestrate-123"
+   *                 workingDirectory: "/tmp/orchestrator"
+   *                 availableAgents:
+   *                   - id: "frontend-agent"
+   *                     name: "Frontend Agent"
+   *                     description: "Handles React/TypeScript frontend development"
+   *                     workingDirectory: "/path/to/frontend"
+   *                     apiEndpoint: "http://frontend-agent:8080"
+   *                   - id: "backend-agent"
+   *                     name: "Backend Agent" 
+   *                     description: "Handles Node.js/Express backend development"
+   *                     workingDirectory: "/path/to/backend"
+   *                     apiEndpoint: "http://backend-agent:8080"
+   *     responses:
+   *       200:
+   *         description: Streaming NDJSON response from orchestrated agents
+   *         content:
+   *           application/x-ndjson:
+   *             schema:
+   *               $ref: '#/components/schemas/StreamResponse'
+   *       400:
+   *         description: Invalid request format
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       500:
+   *         description: Server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   */
   app.post("/api/multi-agent-chat", (c) => handleMultiAgentChatRequest(c, requestAbortControllers));
+
+  // Swagger API documentation routes
+  /**
+   * @swagger
+   * /api-docs:
+   *   get:
+   *     summary: Swagger API documentation UI
+   *     description: Interactive API documentation interface
+   *     tags: [Documentation]
+   *     responses:
+   *       200:
+   *         description: Swagger UI HTML page
+   *         content:
+   *           text/html:
+   *             schema:
+   *               type: string
+   */
+  app.get("/api-docs", (c) => {
+    const swaggerUiCss = `
+      <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@5.0.0/swagger-ui.css" />
+      <style>
+        html { box-sizing: border-box; overflow: -moz-scrollbars-vertical; overflow-y: scroll; }
+        *, *:before, *:after { box-sizing: inherit; }
+        body { margin:0; background: #fafafa; }
+      </style>
+    `;
+    
+    const swaggerUiJs = `
+      <script src="https://unpkg.com/swagger-ui-dist@5.0.0/swagger-ui-bundle.js"></script>
+      <script src="https://unpkg.com/swagger-ui-dist@5.0.0/swagger-ui-standalone-preset.js"></script>
+      <script>
+        window.onload = function() {
+          const ui = SwaggerUIBundle({
+            url: '/api-docs.json',
+            dom_id: '#swagger-ui',
+            deepLinking: true,
+            presets: [
+              SwaggerUIBundle.presets.apis,
+              SwaggerUIStandalonePreset
+            ],
+            plugins: [
+              SwaggerUIBundle.plugins.DownloadUrl
+            ],
+            layout: "StandaloneLayout"
+          });
+        };
+      </script>
+    `;
+    
+    const html = `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Agentrooms API Documentation</title>
+          <meta charset="utf-8"/>
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          ${swaggerUiCss}
+        </head>
+        <body>
+          <div id="swagger-ui"></div>
+          ${swaggerUiJs}
+        </body>
+      </html>
+    `;
+    
+    return c.html(html);
+  });
+
+  /**
+   * @swagger
+   * /api-docs.json:
+   *   get:
+   *     summary: OpenAPI specification in JSON format
+   *     description: Raw OpenAPI 3.0 specification for the Agentrooms API
+   *     tags: [Documentation]
+   *     responses:
+   *       200:
+   *         description: OpenAPI specification
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   */
+  app.get("/api-docs.json", (c) => {
+    return c.json(specs);
+  });
 
   // Static file serving with SPA fallback
   // Serve static assets (CSS, JS, images, etc.)

--- a/backend/package.json
+++ b/backend/package.json
@@ -60,10 +60,14 @@
     "@hono/node-server": "^1.0.0",
     "commander": "^14.0.0",
     "hono": "^4.0.0",
-    "openai": "^4.24.0"
+    "openai": "^4.24.0",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
+    "@types/swagger-jsdoc": "^6.0.4",
+    "@types/swagger-ui-express": "^4.1.6",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "esbuild": "^0.25.6",

--- a/backend/swagger/config.ts
+++ b/backend/swagger/config.ts
@@ -1,0 +1,318 @@
+import swaggerJsdoc from 'swagger-jsdoc';
+
+const options = {
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'Agentrooms API',
+      version: '0.1.40',
+      description: 'Multi-agent development workspace API for managing conversations with remote AI agents',
+      license: {
+        name: 'MIT',
+        url: 'https://opensource.org/licenses/MIT',
+      },
+      contact: {
+        name: 'Agentrooms',
+        url: 'https://github.com/sugyan/claude-code-webui',
+      },
+    },
+    servers: [
+      {
+        url: 'http://localhost:8080',
+        description: 'Development server',
+      },
+    ],
+    components: {
+      schemas: {
+        StreamResponse: {
+          type: 'object',
+          properties: {
+            type: {
+              type: 'string',
+              enum: ['claude_json', 'error', 'done', 'aborted'],
+              description: 'Type of streaming response',
+            },
+            data: {
+              type: 'object',
+              description: 'SDKMessage object for claude_json type',
+            },
+            error: {
+              type: 'string',
+              description: 'Error message if type is error',
+            },
+          },
+          required: ['type'],
+        },
+        ChatRequest: {
+          type: 'object',
+          properties: {
+            message: {
+              type: 'string',
+              description: 'User message or command to send to Claude',
+              example: 'Help me write a function to validate email addresses',
+            },
+            sessionId: {
+              type: 'string',
+              description: 'Optional session ID for conversation continuity',
+              example: 'session-123',
+            },
+            requestId: {
+              type: 'string',
+              description: 'Unique request identifier for abort functionality',
+              example: 'req-456',
+            },
+            allowedTools: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+              description: 'Optional array of allowed tool names',
+              example: ['Read', 'Write', 'Bash'],
+            },
+            workingDirectory: {
+              type: 'string',
+              description: 'Optional working directory for Claude execution',
+              example: '/home/user/my-project',
+            },
+            availableAgents: {
+              type: 'array',
+              items: {
+                $ref: '#/components/schemas/Agent',
+              },
+              description: 'Available agents for multi-agent scenarios',
+            },
+          },
+          required: ['message', 'requestId'],
+        },
+        Agent: {
+          type: 'object',
+          properties: {
+            id: {
+              type: 'string',
+              description: 'Unique agent identifier',
+              example: 'readymojo-api',
+            },
+            name: {
+              type: 'string',
+              description: 'Human-readable agent name',
+              example: 'ReadyMojo API',
+            },
+            description: {
+              type: 'string',
+              description: 'Agent description and specialization',
+              example: 'Backend API and server logic',
+            },
+            workingDirectory: {
+              type: 'string',
+              description: 'Agent working directory path',
+              example: '/home/user/readymojo-api',
+            },
+            apiEndpoint: {
+              type: 'string',
+              description: 'Agent API endpoint URL',
+              example: 'http://207.254.39.121:8080',
+            },
+            isOrchestrator: {
+              type: 'boolean',
+              description: 'Whether this agent is an orchestrator',
+              example: false,
+            },
+          },
+          required: ['id', 'name', 'description', 'workingDirectory', 'apiEndpoint'],
+        },
+        ProjectInfo: {
+          type: 'object',
+          properties: {
+            path: {
+              type: 'string',
+              description: 'Absolute path to the project directory',
+              example: '/home/user/my-project',
+            },
+            encodedName: {
+              type: 'string',
+              description: 'URL-encoded project name for API endpoints',
+              example: 'my-project-abc123',
+            },
+          },
+          required: ['path', 'encodedName'],
+        },
+        ProjectsResponse: {
+          type: 'object',
+          properties: {
+            projects: {
+              type: 'array',
+              items: {
+                $ref: '#/components/schemas/ProjectInfo',
+              },
+              description: 'List of available projects',
+            },
+          },
+          required: ['projects'],
+        },
+        ConversationSummary: {
+          type: 'object',
+          properties: {
+            sessionId: {
+              type: 'string',
+              description: 'Unique session identifier',
+              example: 'session-123',
+            },
+            startTime: {
+              type: 'string',
+              format: 'date-time',
+              description: 'ISO timestamp when conversation started',
+              example: '2024-01-15T10:30:00Z',
+            },
+            lastTime: {
+              type: 'string',
+              format: 'date-time',
+              description: 'ISO timestamp of last message',
+              example: '2024-01-15T11:45:00Z',
+            },
+            messageCount: {
+              type: 'integer',
+              description: 'Total number of messages in conversation',
+              example: 12,
+            },
+            lastMessagePreview: {
+              type: 'string',
+              description: 'Preview of the last message in conversation',
+              example: 'The function looks good! Here are a few suggestions...',
+            },
+            agentId: {
+              type: 'string',
+              description: 'Agent that created this conversation',
+              example: 'readymojo-api',
+            },
+          },
+          required: ['sessionId', 'startTime', 'lastTime', 'messageCount', 'lastMessagePreview'],
+        },
+        HistoryListResponse: {
+          type: 'object',
+          properties: {
+            conversations: {
+              type: 'array',
+              items: {
+                $ref: '#/components/schemas/ConversationSummary',
+              },
+              description: 'List of conversation summaries',
+            },
+          },
+          required: ['conversations'],
+        },
+        ConversationHistory: {
+          type: 'object',
+          properties: {
+            sessionId: {
+              type: 'string',
+              description: 'Unique session identifier',
+              example: 'session-123',
+            },
+            messages: {
+              type: 'array',
+              items: {
+                type: 'object',
+              },
+              description: 'Array of timestamped messages in the conversation',
+            },
+            metadata: {
+              type: 'object',
+              properties: {
+                startTime: {
+                  type: 'string',
+                  format: 'date-time',
+                  description: 'ISO timestamp when conversation started',
+                },
+                endTime: {
+                  type: 'string',
+                  format: 'date-time',
+                  description: 'ISO timestamp when conversation ended',
+                },
+                messageCount: {
+                  type: 'integer',
+                  description: 'Total number of messages',
+                },
+                agentId: {
+                  type: 'string',
+                  description: 'Agent that created this conversation',
+                },
+              },
+              required: ['startTime', 'endTime', 'messageCount'],
+            },
+          },
+          required: ['sessionId', 'messages', 'metadata'],
+        },
+        HealthResponse: {
+          type: 'object',
+          properties: {
+            status: {
+              type: 'string',
+              example: 'ok',
+            },
+            timestamp: {
+              type: 'string',
+              format: 'date-time',
+              example: '2024-01-15T10:30:00.000Z',
+            },
+            service: {
+              type: 'string',
+              example: 'claude-code-web-agent',
+            },
+            version: {
+              type: 'string',
+              example: '0.1.37',
+            },
+          },
+          required: ['status', 'timestamp', 'service', 'version'],
+        },
+        AbortRequest: {
+          type: 'object',
+          properties: {
+            requestId: {
+              type: 'string',
+              description: 'Request ID to abort',
+              example: 'req-456',
+            },
+          },
+          required: ['requestId'],
+        },
+        ErrorResponse: {
+          type: 'object',
+          properties: {
+            error: {
+              type: 'string',
+              description: 'Error message',
+              example: 'Failed to process request',
+            },
+          },
+          required: ['error'],
+        },
+      },
+    },
+    tags: [
+      {
+        name: 'Health',
+        description: 'System health and status endpoints',
+      },
+      {
+        name: 'Chat',
+        description: 'Chat and conversation endpoints',
+      },
+      {
+        name: 'Projects',
+        description: 'Project management endpoints',
+      },
+      {
+        name: 'History',
+        description: 'Conversation history endpoints',
+      },
+      {
+        name: 'Agent Management',
+        description: 'Remote agent management endpoints',
+      },
+    ],
+  },
+  apis: ['./**/*.ts'], // paths to files containing OpenAPI definitions
+};
+
+export const specs = swaggerJsdoc(options);


### PR DESCRIPTION
This PR adds comprehensive Swagger API documentation for all Agentrooms API services.

## Changes
- Add swagger-jsdoc and swagger-ui-express dependencies
- Create OpenAPI 3.0 specification with detailed schemas
- Add JSDoc comments with full documentation for all routes
- Set up /api-docs route with interactive Swagger UI
- Set up /api-docs.json route for raw OpenAPI specification
- Document all chat, project, history, and agent management endpoints

Fixes #30

Generated with [Claude Code](https://claude.ai/code)