### PR TITLE
Fix tagpr to use v prefix for tags

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -8,7 +8,7 @@
 	changelog = true
 
 	# Use "v" prefix for tags (v1.0.0, v1.0.1, etc.)
-	vPrefix = false
+	vPrefix = true
 
 	# Create GitHub Releases automatically
 	release = true


### PR DESCRIPTION
## Description

Fix the tagpr configuration to use `v` prefix for tags so they match the release workflow trigger.

## Problem

- The `.tagpr` config had `vPrefix = false`, creating tags like `0.1.42`
- The release workflow expects tags starting with `v*` (e.g., `v0.1.42`)
- This mismatch prevented the release workflow from triggering

## Solution

Changed `vPrefix = false` to `vPrefix = true` in `.tagpr` config.

## How the automated release flow works now

1. **Push to main** → tagpr creates a PR to prepare the release (updates CHANGELOG, version)
2. **Merge the tagpr PR** → tagpr automatically creates a tag like `v0.1.43`
3. **Tag created** → release workflow triggers and builds Linux, Windows, Mac binaries
4. **Release published** → binaries attached to GitHub release + npm publish

Co-authored-by: openhands <openhands@all-hands.dev>

@baryhuang can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c7980b2b9da74f99b45ed029ebac290e)