### PR TITLE
Release for v0.1.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.1.42](https://github.com/baryhuang/claude-code-by-agents/compare/0.1.42...v0.1.42) - 2026-01-01
+- Fix tagpr to use v prefix for tags by @baryhuang in https://github.com/baryhuang/claude-code-by-agents/pull/43
+- Fix release workflow to trigger on both v* and semver tags by @baryhuang in https://github.com/baryhuang/claude-code-by-agents/pull/45
+- Enable fully automatic releases on every main merge by @baryhuang in https://github.com/baryhuang/claude-code-by-agents/pull/46
+
 ## [0.1.42](https://github.com/baryhuang/claude-code-by-agents/compare/0.1.41...0.1.42) - 2026-01-01
 - fix backend bug by @Xinxin-Ma in https://github.com/baryhuang/claude-code-by-agents/pull/39
 - Fix TypeScript error: ensure boolean return type in shouldUseOrchestrator by @baryhuang in https://github.com/baryhuang/claude-code-by-agents/pull/40


### PR DESCRIPTION
This pull request is for the next release as v0.1.42 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.42 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.7" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Fix tagpr to use v prefix for tags by @baryhuang in https://github.com/baryhuang/claude-code-by-agents/pull/43
* Fix release workflow to trigger on both v* and semver tags by @baryhuang in https://github.com/baryhuang/claude-code-by-agents/pull/45
* Enable fully automatic releases on every main merge by @baryhuang in https://github.com/baryhuang/claude-code-by-agents/pull/46


**Full Changelog**: https://github.com/baryhuang/claude-code-by-agents/compare/0.1.42...v0.1.42