### PR TITLE
Fix release workflow to trigger on both v* and semver tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+      - "[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   # Verify the tag is on main branch before building


### PR DESCRIPTION
## Description

Fix the release workflow to trigger on both tag formats so binaries are built.

## Problem

The release workflow only triggers on `v*` tags, but tagpr was creating tags without the `v` prefix (e.g., `0.1.42` instead of `v0.1.42`). This caused the release `0.1.42` to be created without any binaries.

## Solution

Accept both tag formats:
- `v*` (e.g., `v0.1.42`) - new format going forward
- `[0-9]+.[0-9]+.[0-9]+` (e.g., `0.1.42`) - existing tags without prefix

## After this PR is merged

You can manually trigger a release for `0.1.42` by deleting and recreating the tag:
```bash
git tag -d 0.1.42
git push origin :refs/tags/0.1.42
git tag 0.1.42 c6c15f6
git push origin 0.1.42
```

Or wait for the next release which will work automatically.

Co-authored-by: openhands <openhands@all-hands.dev>

@baryhuang can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c7980b2b9da74f99b45ed029ebac290e)