### PR TITLE
Enable fully automatic releases on every main merge

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -15,6 +15,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_PAT }}
+      
       - uses: Songmu/tagpr@v1
+        id: tagpr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+      
+      # Auto-merge the tagpr PR to trigger automatic releases
+      - name: Auto-merge tagpr PR
+        if: steps.tagpr.outputs.pull_request_number != ''
+        run: |
+          gh pr merge ${{ steps.tagpr.outputs.pull_request_number }} --auto --squash
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
## Description

Make releases fully automatic - every merge to main produces a new release with binaries.

## How it works now

1. **Push/merge to main** → tagpr creates a release PR (bumps version, updates CHANGELOG)
2. **tagpr PR auto-merges immediately** (new step added)
3. **Tag created** → release workflow builds binaries:
   - Linux x64 AppImage
   - Linux ARM64 AppImage  
   - macOS universal DMG
   - Windows portable exe
4. **Release published** with all binaries attached

## Changes

Added auto-merge step to `tagpr.yml`:
```yaml
- name: Auto-merge tagpr PR
  if: steps.tagpr.outputs.pull_request_number != ''
  run: |
    gh pr merge ${{ steps.tagpr.outputs.pull_request_number }} --auto --squash
  env:
    GITHUB_TOKEN: ${{ secrets.GH_PAT }}
```

## Requirements

- GitHub repo must have "Allow auto-merge" enabled in Settings → General → Pull Requests
- Branch protection rules (if any) must allow the auto-merge

Co-authored-by: openhands <openhands@all-hands.dev>

@baryhuang can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c7980b2b9da74f99b45ed029ebac290e)