### PR TITLE
Fix ARM64 cross-compilation in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y python3-setuptools
 
+      - name: Install ARM64 cross-compilation tools (Linux ARM64 only)
+        if: matrix.os == 'ubuntu-latest' && matrix.arch == 'arm64'
+        run: |
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
       - name: Setup Python (macOS)
         if: matrix.os == 'macos-latest'
         uses: actions/setup-python@v4
@@ -108,6 +113,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_IDENTITY_AUTO_DISCOVERY: false
+          # For ARM64 cross-compilation on x64 runner
+          npm_config_arch: ${{ matrix.arch }}
+          npm_config_target_arch: ${{ matrix.arch }}
 
       - name: List dist directory
         run: ls -la dist/


### PR DESCRIPTION
## Problem

The release workflow for tag `v0.1.42` failed at the "Build Electron app" step. The Linux ARM64 build was failing because cross-compilation tools weren't installed.

## Root Cause

Building ARM64 binaries on an x64 GitHub Actions runner requires:
1. ARM64 cross-compilation toolchain (`gcc-aarch64-linux-gnu`, `g++-aarch64-linux-gnu`)
2. Environment variables to tell npm/node-gyp to target ARM64 architecture

## Solution

Added:
- Install ARM64 cross-compilation tools for Linux ARM64 builds
- Set `npm_config_arch` and `npm_config_target_arch` environment variables

## Changes

```yaml
- name: Install ARM64 cross-compilation tools (Linux ARM64 only)
  if: matrix.os == 'ubuntu-latest' && matrix.arch == 'arm64'
  run: |
    sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu

- name: Build Electron app
  run: npx electron-builder ${{ matrix.electron_args }}
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    CSC_IDENTITY_AUTO_DISCOVERY: false
    npm_config_arch: ${{ matrix.arch }}
    npm_config_target_arch: ${{ matrix.arch }}
```

After merging, the next tag should successfully build all binaries.

Co-authored-by: openhands <openhands@all-hands.dev>

@baryhuang can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c7980b2b9da74f99b45ed029ebac290e)