### PR TITLE
Move electron to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,9 +100,7 @@
     }
   },
   "devDependencies": {
+    "electron": "^37.4.0",
     "electron-builder": "^25.1.8"
-  },
-  "dependencies": {
-    "electron": "^37.4.0"
   }
 }


### PR DESCRIPTION
## Problem

Release build failing with:
```
⨯ Package "electron" is only allowed in "devDependencies". Please remove it from the "dependencies" section in your package.json.
```

## Solution

Move `electron` from `dependencies` to `devDependencies` as required by electron-builder.

## Changes

```diff
  "devDependencies": {
+   "electron": "^37.4.0",
    "electron-builder": "^25.1.8"
- },
- "dependencies": {
-   "electron": "^37.4.0"
  }
```

Co-authored-by: openhands <openhands@all-hands.dev>

@baryhuang can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c7980b2b9da74f99b45ed029ebac290e)