### PR TITLE
Fix release binary version to match tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,15 @@ jobs:
           node-version: "22"
           cache: "npm"
 
+      - name: Update version from tag
+        run: |
+          # Extract version from tag (remove 'v' prefix if present)
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          echo "Setting version to: $VERSION"
+          # Update package.json version
+          npm version $VERSION --no-git-tag-version --allow-same-version
+
       - name: Install dependencies
         run: npm install
 


### PR DESCRIPTION
## Problem

Release binaries are named with hardcoded version `0.0.7` (e.g., `Agentrooms-0.0.7.dmg`) instead of the actual release version from the tag.

## Solution

Add a step to update `package.json` version from the git tag before building:

```yaml
- name: Update version from tag
  run: |
    # Extract version from tag (remove 'v' prefix if present)
    VERSION="${{ github.ref_name }}"
    VERSION="${VERSION#v}"
    echo "Setting version to: $VERSION"
    # Update package.json version
    npm version $VERSION --no-git-tag-version --allow-same-version
```

## Result

After this fix, binaries will be named correctly:
- `Agentrooms-0.1.45.dmg` (instead of `Agentrooms-0.0.7.dmg`)
- `Agentrooms-0.1.45-arm64.AppImage`
- etc.

Co-authored-by: openhands <openhands@all-hands.dev>

@baryhuang can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c7980b2b9da74f99b45ed029ebac290e)