### PR TITLE
Fix Windows build: use bash shell for version update step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,7 @@ jobs:
           cache: "npm"
 
       - name: Update version from tag
+        shell: bash
         run: |
           # Extract version from tag (remove 'v' prefix if present)
           VERSION="${{ github.ref_name }}"


### PR DESCRIPTION
## Problem

Windows build failing with:
```
The term 'VERSION=v0.1.45' is not recognized as a name of a cmdlet, function, script file, or executable program.
```

## Root Cause

Windows runners use PowerShell by default, which doesn't support bash variable syntax like `VERSION="${VERSION#v}"`.

## Solution

Add `shell: bash` to the version update step to ensure it runs in bash on all platforms.

```yaml
- name: Update version from tag
  shell: bash  # <-- Added this
  run: |
    VERSION="${{ github.ref_name }}"
    ...
```

Co-authored-by: openhands <openhands@all-hands.dev>

@baryhuang can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c7980b2b9da74f99b45ed029ebac290e)