### PR TITLE
Release for v0.1.46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.1.46](https://github.com/baryhuang/claude-code-by-agents/compare/v0.1.45...v0.1.46) - 2026-01-01
+- Fix Windows build: use bash shell for version update step by @baryhuang in https://github.com/baryhuang/claude-code-by-agents/pull/55
+
 ## [v0.1.45](https://github.com/baryhuang/claude-code-by-agents/compare/v0.1.44...v0.1.45) - 2026-01-01
 - Remove npm-publish step from release workflow by @baryhuang in https://github.com/baryhuang/claude-code-by-agents/pull/52
 - Fix release binary version to match tag by @baryhuang in https://github.com/baryhuang/claude-code-by-agents/pull/53

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentrooms",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "type": "module",
   "description": "Agentrooms - Multi-agent workspace for collaborative development",
   "keywords": [


### PR DESCRIPTION
This pull request is for the next release as v0.1.46 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.46 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.45" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Fix Windows build: use bash shell for version update step by @baryhuang in https://github.com/baryhuang/claude-code-by-agents/pull/55


**Full Changelog**: https://github.com/baryhuang/claude-code-by-agents/compare/v0.1.45...tagpr-from-v0.1.45