### PR TITLE
fix: rebrand Agentrooms to Claude Ops-Deck by Axiom-Labs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,10 +3,6 @@
 # This port is used by both backend and frontend development servers
 PORT=8080
 
-# API Configuration
-# Set to "true" to use local backend during development, otherwise uses orchestrator agent's API endpoint
-VITE_USE_LOCAL_API=false
-
 # OpenAI API Configuration
 # API key for OpenAI access (used by UX Designer agent)
 # Get your API key from: https://platform.openai.com/api-keys
@@ -17,15 +13,8 @@ OPENAI_API_KEY=your-openai-api-key-here
 # Get your API key from: https://console.anthropic.com/
 ANTHROPIC_API_KEY=your-anthropic-api-key-here
 
-# Usage Examples:
-# 1. Use orchestrator agent's API endpoint (default):
-#    VITE_USE_LOCAL_API=false
-#    Configure API endpoint in Settings > Agents > Orchestrator Agent
-#
-# 2. Use local backend for development:
-#    VITE_USE_LOCAL_API=true
-#    PORT=9000 npm run dev  (for frontend)
-#    PORT=9000 deno task dev  (for backend)
-#
-# The frontend will use the orchestrator agent's API endpoint by default
-# Set VITE_USE_LOCAL_API=true to override and use local backend via Vite proxy
+# Usage:
+# The app runs its own local backend (default: http://localhost:8080).
+# In development, Vite proxies /api requests to the backend automatically.
+# Configure each agent's API endpoint in Settings > Agents.
+# For remote agents, point the endpoint to their machine (e.g., http://207.254.39.121:8080).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
             platform: win
             arch: x64
             electron_args: "--win --x64"
-            artifact_pattern: "Agentrooms*"
+            artifact_pattern: "Claude Ops-Deck*"
 
     steps:
       - name: Checkout code
@@ -134,7 +134,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: agentrooms-${{ matrix.platform }}-${{ matrix.arch }}
+          name: claude-ops-deck-${{ matrix.platform }}-${{ matrix.arch }}
           path: dist/${{ matrix.artifact_pattern }}
 
   release:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Agentrooms - Multi-Agent Development Workspace
+# Claude Ops-Deck by Axiom-Labs - AI Agent Mission Control
 
 ## Product Vision
 

--- a/ClaudeAgentHub/ClaudeAgentHub/Models/Agent.swift
+++ b/ClaudeAgentHub/ClaudeAgentHub/Models/Agent.swift
@@ -25,7 +25,7 @@ struct Agent: Codable, Identifiable, Hashable {
             name: "Orchestrator Agent",
             description: "Orchestrates multi-agent conversations",
             workingDirectory: "/tmp/orchestrator",
-            apiEndpoint: "https://api.claudecode.run",
+            apiEndpoint: "http://localhost:8080",
             isOrchestrator: true
         )
     ]

--- a/ClaudeAgentHub/ClaudeAgentHub/Models/AppSettings.swift
+++ b/ClaudeAgentHub/ClaudeAgentHub/Models/AppSettings.swift
@@ -2,7 +2,7 @@ import Foundation
 
 class AppSettings: ObservableObject {
     @Published var agents: [Agent] = []
-    @Published var apiBaseURL: String = "https://api.claudecode.run"
+    @Published var apiBaseURL: String = "http://localhost:8080"
     @Published var selectedProjectPath: String?
     @Published var isDarkMode: Bool = false
     @Published var enableHapticFeedback: Bool = true
@@ -37,7 +37,7 @@ class AppSettings: ObservableObject {
         }
         
         // Load other settings
-        apiBaseURL = userDefaults.string(forKey: Keys.apiBaseURL) ?? "https://api.claudecode.run"
+        apiBaseURL = userDefaults.string(forKey: Keys.apiBaseURL) ?? "http://localhost:8080"
         selectedProjectPath = userDefaults.string(forKey: Keys.selectedProjectPath)
         isDarkMode = userDefaults.bool(forKey: Keys.isDarkMode)
         enableHapticFeedback = userDefaults.bool(forKey: Keys.enableHapticFeedback)

--- a/ClaudeAgentHub/ClaudeAgentHub/Utils/Constants.swift
+++ b/ClaudeAgentHub/ClaudeAgentHub/Utils/Constants.swift
@@ -97,7 +97,7 @@ struct Constants {
     struct Network {
         static let defaultTimeout: TimeInterval = 30
         static let streamingTimeout: TimeInterval = 300
-        static let defaultAPIBaseURL = "https://api.claudecode.run"
+        static let defaultAPIBaseURL = "http://localhost:8080"
     }
     
     // MARK: - Haptic Feedback

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Claude Code Agentrooms UI + Remote Claude Code API
+# Claude Ops-Deck by Axiom-Labs
 
-Multi-agent workspace for collaborative development with Claude CLI. Route tasks to specialized agents (local or remote), coordinate complex workflows.
+AI Agent Mission Control for collaborative development with Claude CLI. Route tasks to specialized agents (local or remote), coordinate complex workflows.
 
 > **Current Status**: This version supports one agent room. Multiple rooms support is planned for future releases - contributions welcome!
 
@@ -40,7 +40,7 @@ https://github.com/user-attachments/assets/0b4e6709-d9b9-4676-85e0-aec8e15fd097
 1. **Claude Subscription**: Requires Claude Pro, Team, or Enterprise subscription
 2. **Install Claude CLI**: Download from [Claude Code documentation](https://docs.anthropic.com/en/docs/claude-code)
 3. **Authenticate**: Run `claude auth login` and complete OAuth authentication
-   - This connects Agentrooms to your Claude subscription
+   - This connects Claude Ops-Deck to your Claude subscription
    - No API keys needed - uses OAuth tokens securely
 
 ### Option 1: Desktop App (Recommended)
@@ -90,7 +90,7 @@ cd backend && deno task dev
 ```
 
 **Configure Frontend to Connect:**
-- Open the Agentrooms app (Windows: run .exe installer, macOS: drag to Applications, Linux: make executable and run)
+- Open the Claude Ops-Deck app (Windows: run .exe installer, macOS: drag to Applications, Linux: make executable and run)
 - Frontend will automatically connect to `localhost:8080`
 - If backend is on different port, update frontend config
 

--- a/README_BUILD.md
+++ b/README_BUILD.md
@@ -1,4 +1,4 @@
-# AgentHub - Multi-Agent Programming Collaboration Tool
+# Claude Ops-Deck - Multi-Agent Programming Collaboration Tool
 
 This is a complete Electron desktop application based on the Claude Code Web Agent, redesigned to match the Claude Desktop App's exact styling with multi-agent chat capabilities.
 
@@ -11,9 +11,9 @@ This is a complete Electron desktop application based on the Claude Code Web Age
 - Makefile build system with DMG generation support
 - Application icons and macOS entitlements
 - Multi-agent system with 4 predefined agents:
-  - ReadyMojo Admin (Blue) - `/Users/buryhuang/git/readymojo-admin`
-  - ReadyMojo API (Green) - `/Users/buryhuang/git/readymojo-api` 
-  - ReadyMojo Web (Purple) - `/Users/buryhuang/git/readymojo-web`
+  - Project Admin (Blue) - `/Users/buryhuang/git/project-admin`
+  - Project API (Green) - `/Users/buryhuang/git/project-api`
+  - Project Web (Purple) - `/Users/buryhuang/git/project-web`
   - PeakMojo Kit (Orange) - `/Users/buryhuang/git/peakmojo-kit`
 
 ## Build System

--- a/STREAMING_DEPLOYMENT.md
+++ b/STREAMING_DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Streaming Deployment Configuration
 
-This document provides configuration guidance for deploying Agentrooms with streaming support in cloud environments.
+This document provides configuration guidance for deploying Claude Ops-Deck with streaming support in cloud environments.
 
 ## Common Issue: Proxy Buffering
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,6 @@
-# Claude Code Agentrooms UI + Remote Claude Code API
+# Claude Ops-Deck by Axiom-Labs
 
-Multi-agent workspace for collaborative development with Claude CLI. Route tasks to specialized agents (local or remote), coordinate complex workflows.
+AI Agent Mission Control for collaborative development with Claude CLI. Route tasks to specialized agents (local or remote), coordinate complex workflows.
 
 > **Current Status**: This version supports one agent room. Multiple rooms support is planned for future releases - contributions welcome!
 
@@ -80,7 +80,7 @@ cd backend && deno task dev
 ```
 
 **Configure Frontend to Connect:**
-- Open the Agentrooms app (Windows: run .exe installer, macOS: drag to Applications, Linux: make executable and run)
+- Open the Claude Ops-Deck app (Windows: run .exe installer, macOS: drag to Applications, Linux: make executable and run)
 - Frontend will automatically connect to `localhost:8080`
 - If backend is on different port, update frontend config
 

--- a/backend/app.ts
+++ b/backend/app.ts
@@ -98,7 +98,7 @@ export function createApp(
    * /api/health:
    *   get:
    *     summary: Health check endpoint
-   *     description: Returns the current status and basic information about the Agentrooms service
+   *     description: Returns the current status and basic information about the Claude Ops-Deck service
    *     tags: [Health]
    *     responses:
    *       200:
@@ -532,7 +532,7 @@ export function createApp(
       <!DOCTYPE html>
       <html>
         <head>
-          <title>Agentrooms API Documentation</title>
+          <title>Claude Ops-Deck API Documentation</title>
           <meta charset="utf-8"/>
           <meta name="viewport" content="width=device-width, initial-scale=1">
           ${swaggerUiCss}
@@ -552,7 +552,7 @@ export function createApp(
    * /api-docs.json:
    *   get:
    *     summary: OpenAPI specification in JSON format
-   *     description: Raw OpenAPI 3.0 specification for the Agentrooms API
+   *     description: Raw OpenAPI 3.0 specification for the Claude Ops-Deck API
    *     tags: [Documentation]
    *     responses:
    *       200:

--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -221,6 +221,7 @@ async function* executeOrchestratorWorkflow(
     name: string;
     description: string;
     isOrchestrator?: boolean;
+    role?: string;
   }>,
   _claudeAuth?: ChatRequest['claudeAuth'],
 ): AsyncGenerator<StreamResponse> {
@@ -304,9 +305,11 @@ async function* executeOrchestratorWorkflow(
       }
     ];
 
-    const agentDescriptions = workerAgents.map(agent => 
-      `- ${agent.id}: ${agent.description}`
-    ).join('\n');
+    const agentDescriptions = workerAgents.map(agent => {
+      const role = availableAgents?.find(a => a.id === agent.id)?.role;
+      const roleStr = role ? ` [${role}]` : '';
+      return `- ${agent.id}${roleStr}: ${agent.description}`;
+    }).join('\n');
 
     const systemPrompt = `You are the Orchestrator agent. Break user requests into steps where each agent saves results to a plain text file, and the next agent reads from that file.
 
@@ -478,6 +481,7 @@ async function* executeClaudeCommand(
   workingDirectory?: string,
   claudeAuth?: ChatRequest['claudeAuth'],
   debugMode?: boolean,
+  systemPrompt?: string,
 ): AsyncGenerator<StreamResponse> {
   let abortController: AbortController;
 
@@ -560,6 +564,7 @@ async function* executeClaudeCommand(
           ...(sessionId ? { resume: sessionId } : {}),
           ...(allowedTools ? { allowedTools } : {}),
           ...(workingDirectory ? { cwd: workingDirectory } : {}),
+          ...(systemPrompt ? { systemPrompt: systemPrompt } : {}),
           permissionMode: "bypassPermissions" as const,
         },
       })) {
@@ -740,6 +745,7 @@ export async function handleChatRequest(
             chatRequest.workingDirectory,
             chatRequest.claudeAuth,
             debugMode,
+            chatRequest.systemPrompt,
           );
         }
 

--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -234,9 +234,9 @@ async function* executeOrchestratorWorkflow(
 
     // Get worker agents (exclude orchestrator)
     const workerAgents = availableAgents?.filter(agent => !agent.isOrchestrator) || [
-      { id: "readymojo-admin", name: "ReadyMojo Admin", description: "Admin dashboard and management interface" },
-      { id: "readymojo-api", name: "ReadyMojo API", description: "Backend API and server logic" },
-      { id: "readymojo-web", name: "ReadyMojo Web", description: "Frontend web application" },
+      { id: "project-admin", name: "Project Admin", description: "Admin dashboard and management interface" },
+      { id: "project-api", name: "Project API", description: "Backend API and server logic" },
+      { id: "project-web", name: "Project Web", description: "Frontend web application" },
       { id: "peakmojo-kit", name: "PeakMojo Kit", description: "UI component library and design system" }
     ];
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "agentrooms",
-  "version": "0.1.41",
+  "name": "claude-ops-deck",
+  "version": "0.1.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "agentrooms",
-      "version": "0.1.41",
+      "name": "claude-ops-deck",
+      "version": "0.1.46",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-code": "1.0.51",
@@ -24,7 +24,7 @@
         "swagger-ui-express": "^5.0.0"
       },
       "bin": {
-        "agentrooms": "dist/cli/node.js"
+        "claude-ops-deck": "dist/cli/node.js"
       },
       "devDependencies": {
         "@dotenvx/dotenvx": "^1.51.1",
@@ -189,6 +189,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1170,6 +1171,7 @@
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -1715,6 +1717,7 @@
       "integrity": "sha512-FuYgkHwZLuPbZjQHzJXrtXreJdFMKl16BFYyRrLxDhWr6Qr7Kbcu2s1Yhu8tsiMXw1S0W1pjfFfYEt+R604s+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.36.0",
         "@typescript-eslint/types": "8.36.0",
@@ -2056,7 +2059,6 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -2071,6 +2073,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2173,7 +2176,6 @@
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
       "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
@@ -2217,7 +2219,6 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2237,7 +2238,6 @@
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -2251,7 +2251,6 @@
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -2363,7 +2362,6 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
       "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "5.2.1"
       },
@@ -2376,7 +2374,6 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2386,7 +2383,6 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2396,7 +2392,6 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.6.0"
       }
@@ -2464,7 +2459,6 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2499,7 +2493,6 @@
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -2538,8 +2531,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -2553,7 +2545,6 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2563,7 +2554,6 @@
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2573,7 +2563,6 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2590,7 +2579,6 @@
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -2644,8 +2632,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -2666,6 +2653,7 @@
       "integrity": "sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2829,7 +2817,6 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3042,7 +3029,6 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
       "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "encodeurl": "^2.0.0",
@@ -3145,7 +3131,6 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3155,7 +3140,6 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3186,7 +3170,6 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -3196,7 +3179,6 @@
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -3221,7 +3203,6 @@
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -3327,7 +3308,6 @@
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3357,7 +3337,6 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3370,7 +3349,6 @@
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -3383,6 +3361,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.8.4.tgz",
       "integrity": "sha512-KOIBp1+iUs0HrKztM4EHiB2UtzZDTBihDtOF5K6+WaJjCPeaW4Q92R8j63jOhvJI5+tZSMuKD9REVEXXY9illg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3392,7 +3371,6 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "depd": "2.0.0",
         "inherits": "2.0.4",
@@ -3409,7 +3387,6 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3438,7 +3415,6 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -3505,7 +3481,6 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -3557,8 +3532,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -3728,7 +3702,6 @@
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -3738,7 +3711,6 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3748,7 +3720,6 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -3792,7 +3763,6 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3802,7 +3772,6 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
       "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -3879,7 +3848,6 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3940,7 +3908,6 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3963,7 +3930,6 @@
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -4087,7 +4053,6 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -4143,7 +4108,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
       "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16"
       }
@@ -4245,7 +4209,6 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -4269,7 +4232,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -4306,7 +4268,6 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4316,7 +4277,6 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
       "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -4423,7 +4383,6 @@
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "depd": "^2.0.0",
@@ -4477,15 +4436,13 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.2",
@@ -4505,7 +4462,6 @@
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
       "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.3.5",
         "encodeurl": "^2.0.0",
@@ -4528,7 +4484,6 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
       "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
@@ -4543,8 +4498,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4574,7 +4528,6 @@
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -4594,7 +4547,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3"
@@ -4611,7 +4563,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -4630,7 +4581,6 @@
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -4687,7 +4637,6 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -4987,7 +4936,6 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -5043,7 +4991,6 @@
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
       "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "content-type": "^1.0.5",
         "media-typer": "^1.1.0",
@@ -5059,6 +5006,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5079,7 +5027,6 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -5108,7 +5055,6 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -5119,6 +5065,7 @@
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "agentrooms",
+  "name": "claude-ops-deck",
   "version": "0.1.46",
   "type": "module",
-  "description": "Agentrooms - Multi-agent workspace for collaborative development",
+  "description": "Claude Ops-Deck - Multi-agent workspace for collaborative development",
   "keywords": [
-    "agentrooms",
+    "claude-ops-deck",
     "multi-agent",
     "ai",
     "workspace",
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/sugyan/claude-code-webui#readme",
   "main": "dist/cli/node.js",
   "bin": {
-    "agentrooms": "dist/cli/node.js"
+    "claude-ops-deck": "dist/cli/node.js"
   },
   "files": [
     "dist/",

--- a/backend/providers/anthropic.ts
+++ b/backend/providers/anthropic.ts
@@ -82,7 +82,7 @@ export class AnthropicProvider implements AgentProvider {
         temperature,
         max_tokens: maxTokens,
         stream: true,
-        system: "You are Claude, a helpful AI assistant created by Anthropic. You help users coordinate multiple AI agents working on different parts of projects, each with specialized skills and access to different codebases. When working in orchestrator mode, you help plan and coordinate tasks across multiple agents."
+        system: "You are Claude, a helpful AI assistant created by Anthropic. You help users coordinate multiple AI agents working on different parts of projects, each with specialized skills and access to different codebases. When working in orchestrator mode, you help plan and coordinate tasks across multiple agents." + (request.systemPrompt ? `\n\nAdditional instructions: ${request.systemPrompt}` : "")
       };
       
       const response = await fetch(this.baseUrl, {

--- a/backend/providers/claude-code.ts
+++ b/backend/providers/claude-code.ts
@@ -100,6 +100,7 @@ export class ClaudeCodeProvider implements AgentProvider {
             pathToClaudeCodeExecutable: this.claudePath,
             ...(request.sessionId ? { resume: request.sessionId } : {}),
             ...(request.workingDirectory ? { cwd: request.workingDirectory } : {}),
+            ...(request.systemPrompt ? { systemPrompt: request.systemPrompt } : {}),
             permissionMode: "bypassPermissions" as const,
           },
         })) {

--- a/backend/providers/openai.ts
+++ b/backend/providers/openai.ts
@@ -46,11 +46,11 @@ export class OpenAIProvider implements AgentProvider {
 
 When analyzing screenshots:
 1. **Visual Hierarchy**: Comment on layout, spacing, typography hierarchy
-2. **User Experience**: Identify usability issues, navigation problems, accessibility concerns  
+2. **User Experience**: Identify usability issues, navigation problems, accessibility concerns
 3. **Design Quality**: Evaluate color choices, consistency, visual appeal
 4. **Improvement Suggestions**: Provide specific, implementable recommendations
 
-Format your responses with clear sections and actionable recommendations. Be constructive and specific in your feedback.`
+Format your responses with clear sections and actionable recommendations. Be constructive and specific in your feedback.` + (request.systemPrompt ? `\n\nAdditional instructions: ${request.systemPrompt}` : "")
       });
       
       // Add context messages if provided

--- a/backend/providers/registry.ts
+++ b/backend/providers/registry.ts
@@ -11,6 +11,9 @@ export interface AgentConfiguration {
   apiEndpoint?: string; // For remote agents
   workingDirectory?: string;
   isOrchestrator?: boolean;
+  systemPrompt?: string;
+  allowedTools?: string[];
+  role?: string;
   config?: {
     apiKey?: string; // For OpenAI
     claudePath?: string; // For Claude Code

--- a/backend/providers/types.ts
+++ b/backend/providers/types.ts
@@ -25,6 +25,7 @@ export interface ProviderChatRequest {
   sessionId?: string;
   requestId: string;
   workingDirectory?: string;
+  systemPrompt?: string;
   images?: ProviderImage[];
   context?: ProviderContext[];
 }

--- a/backend/swagger/config.ts
+++ b/backend/swagger/config.ts
@@ -4,7 +4,7 @@ const options = {
   definition: {
     openapi: '3.0.0',
     info: {
-      title: 'Agentrooms API',
+      title: 'Claude Ops-Deck API',
       version: '0.1.40',
       description: 'Multi-agent development workspace API for managing conversations with remote AI agents',
       license: {
@@ -12,7 +12,7 @@ const options = {
         url: 'https://opensource.org/licenses/MIT',
       },
       contact: {
-        name: 'Agentrooms',
+        name: 'Axiom-Labs',
         url: 'https://github.com/sugyan/claude-code-webui',
       },
     },
@@ -90,12 +90,12 @@ const options = {
             id: {
               type: 'string',
               description: 'Unique agent identifier',
-              example: 'readymojo-api',
+              example: 'project-api',
             },
             name: {
               type: 'string',
               description: 'Human-readable agent name',
-              example: 'ReadyMojo API',
+              example: 'Project API',
             },
             description: {
               type: 'string',
@@ -105,7 +105,7 @@ const options = {
             workingDirectory: {
               type: 'string',
               description: 'Agent working directory path',
-              example: '/home/user/readymojo-api',
+              example: '/home/user/project-api',
             },
             apiEndpoint: {
               type: 'string',
@@ -182,7 +182,7 @@ const options = {
             agentId: {
               type: 'string',
               description: 'Agent that created this conversation',
-              example: 'readymojo-api',
+              example: 'project-api',
             },
           },
           required: ['sessionId', 'startTime', 'lastTime', 'messageCount', 'lastMessagePreview'],

--- a/backend/tests/node/runtime.test.ts
+++ b/backend/tests/node/runtime.test.ts
@@ -57,7 +57,7 @@ describe("Node.js Runtime", () => {
 
     // Verify it's actually JSON
     const parsed = JSON.parse(content);
-    expect(parsed.name).toBe("agentrooms");
+    expect(parsed.name).toBe("claude-ops-deck");
   });
 
   it("should execute commands", async () => {

--- a/backend/tests/utils/imageHandling.test.ts
+++ b/backend/tests/utils/imageHandling.test.ts
@@ -17,7 +17,7 @@ vi.mock("fs", () => ({
 
 describe("ImageHandler", () => {
   let imageHandler: ImageHandler;
-  const testTempDir = "/tmp/test-agentrooms";
+  const testTempDir = "/tmp/test-claude-ops-deck";
   
   beforeEach(() => {
     vi.clearAllMocks();

--- a/backend/utils/imageHandling.ts
+++ b/backend/utils/imageHandling.ts
@@ -20,7 +20,7 @@ export interface ScreenshotCapture {
 export class ImageHandler {
   private tempDir: string;
   
-  constructor(tempDir: string = "/tmp/agentrooms") {
+  constructor(tempDir: string = "/tmp/claude-ops-deck") {
     this.tempDir = tempDir;
   }
   

--- a/electron/main.js
+++ b/electron/main.js
@@ -147,7 +147,7 @@ function createWindow() {
         <!DOCTYPE html>
         <html>
         <head>
-          <title>Agentrooms - Loading Error</title>
+          <title>Claude Ops-Deck - Loading Error</title>
           <style>
             body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; 
                    padding: 20px; background: #1a1d1a; color: white; }
@@ -280,15 +280,15 @@ app.on('before-quit', () => {
 if (process.platform === 'darwin') {
   const template = [
     {
-      label: 'Agentrooms',
+      label: 'Claude Ops-Deck',
       submenu: [
         {
-          label: 'About Agentrooms',
+          label: 'About Claude Ops-Deck',
           role: 'about'
         },
         { type: 'separator' },
         {
-          label: 'Hide Agentrooms',
+          label: 'Hide Claude Ops-Deck',
           accelerator: 'Command+H',
           role: 'hide'
         },

--- a/electron/main.js
+++ b/electron/main.js
@@ -34,7 +34,7 @@ let backendProcess;
 let storage;
 
 // Set a consistent user data path for localStorage persistence
-app.setPath('userData', path.join(app.getPath('appData'), 'Agentrooms'));
+app.setPath('userData', path.join(app.getPath('appData'), 'Claude Ops-Deck'));
 
 const isDev = process.env.NODE_ENV === 'development';
 
@@ -54,7 +54,7 @@ function createWindow() {
       webSecurity: true,
       preload: path.join(__dirname, 'preload.js'),
       // Ensure partition for persistent storage
-      partition: 'persist:agentrooms',
+      partition: 'persist:claude-ops-deck',
       // Additional security settings
       sandbox: false, // We need this false for preload script
       safeDialogs: true,

--- a/electron/storage.js
+++ b/electron/storage.js
@@ -5,7 +5,7 @@ const { app } = require('electron');
 class ElectronStorage {
   constructor() {
     this.userDataPath = app.getPath('userData');
-    this.storagePath = path.join(this.userDataPath, 'agentrooms-data');
+    this.storagePath = path.join(this.userDataPath, 'claude-ops-deck-data');
     
     // Ensure storage directory exists
     if (!fs.existsSync(this.storagePath)) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Agentrooms</title>
+    <title>Claude Ops-Deck</title>
     <!-- Content Security Policy for Electron security -->
     <meta http-equiv="Content-Security-Policy" content="
       default-src 'self' data: blob:;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -104,7 +104,6 @@
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
@@ -120,7 +119,6 @@
       "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -223,6 +221,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -246,6 +245,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2130,8 +2130,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.2",
@@ -2170,6 +2169,7 @@
       "integrity": "sha512-yZQa2zm87aRVcqDyH5+4Hv9KYgSdgwX1rFnGvpbzMaC7YAljmhBET93TPiTd3ObwTL+gSpIzPKg5BqVxdCvxKg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.8.0"
       }
@@ -2180,6 +2180,7 @@
       "integrity": "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2190,6 +2191,7 @@
       "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -2240,6 +2242,7 @@
       "integrity": "sha512-qwxv6dq682yVvgKKp2qWwLgRbscDAYktPptK4JPojCwwi3R9cwrvIxS4lvBpzmcqzR4bdn54Z0IG1uHFskW4dA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.33.1",
         "@typescript-eslint/types": "8.33.1",
@@ -2586,6 +2589,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2636,7 +2640,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2955,8 +2958,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.1",
@@ -3052,6 +3054,7 @@
       "integrity": "sha512-ocgh41VhRlf9+fVpe7QKzwLj9c92fDiqOj8Y3Sd4/ZmVA4Btx4PlUYPq4pp9JDyupkf1upbEXecxL2mwNV7jPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3610,8 +3613,7 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -3632,6 +3634,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -4009,7 +4012,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4391,7 +4393,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4407,7 +4408,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4451,6 +4451,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4460,6 +4461,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -4472,8 +4474,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-router": {
       "version": "7.6.2",
@@ -4888,6 +4889,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5011,6 +5013,7 @@
       "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -5044,6 +5047,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5098,6 +5102,7 @@
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5211,6 +5216,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agentrooms-frontend",
+  "name": "claude-ops-deck-frontend",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/frontend/src/components/MessageComponents.tsx
+++ b/frontend/src/components/MessageComponents.tsx
@@ -9,6 +9,7 @@ import type {
 import { CollapsibleDetails } from "./messages/CollapsibleDetails";
 import { MESSAGE_CONSTANTS } from "../utils/constants";
 import { useAgentConfig } from "../hooks/useAgentConfig";
+import { AgentAvatar } from "./shared/AgentAvatar";
 
 interface ChatMessageComponentProps {
   message: ChatMessage;
@@ -36,14 +37,13 @@ export function ChatMessageComponent({ message }: ChatMessageComponentProps) {
   return (
     <div className="message-item animate-in">
       {/* Avatar */}
-      <div 
-        className={`message-avatar ${isUser ? 'user' : ''}`}
-        style={!isUser && agent ? { 
-          backgroundColor: `var(--agent-${agent.id.replace('readymojo-', '').replace('peakmojo-', '')})`
-        } : {}}
-      >
-        {isUser ? "U" : agent?.name.charAt(0) || "C"}
-      </div>
+      {!isUser && agent ? (
+        <AgentAvatar size="md" agent={agent} />
+      ) : (
+        <div className={`message-avatar ${isUser ? 'user' : ''}`}>
+          {isUser ? "U" : "C"}
+        </div>
+      )}
 
       {/* Message Content */}
       <div className="message-content">
@@ -191,8 +191,8 @@ export function OrchestrationMessageComponent({
   return (
     <div className="message-item animate-in">
       {/* Avatar */}
-      <div className="message-avatar" style={{ background: 'linear-gradient(135deg, var(--agent-admin), var(--agent-web))' }}>
-        GC
+      <div className="message-avatar" style={{ background: 'linear-gradient(135deg, var(--claude-text-accent), var(--agent-web))' }}>
+        AR
       </div>
 
       {/* Message Content */}
@@ -295,15 +295,7 @@ export function OrchestrationMessageComponent({
                     marginBottom: '4px'
                   }}>
                     {agent && (
-                      <div 
-                        style={{
-                          width: '8px',
-                          height: '8px',
-                          borderRadius: '50%',
-                          backgroundColor: `var(--agent-${agent.id.replace('readymojo-', '').replace('peakmojo-', '')})`,
-                          flexShrink: 0
-                        }}
-                      />
+                      <AgentAvatar size="sm" agent={agent} />
                     )}
                     <span style={{
                       fontSize: '12px',
@@ -360,9 +352,13 @@ export function LoadingComponent({ agentId }: LoadingComponentProps = {}) {
   return (
     <div className="message-item animate-in">
       {/* Avatar */}
-      <div className="message-avatar">
-        {avatarLetter}
-      </div>
+      {agent ? (
+        <AgentAvatar size="md" agent={agent} />
+      ) : (
+        <div className="message-avatar">
+          {avatarLetter}
+        </div>
+      )}
 
       {/* Message Content */}
       <div className="message-content">

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -2,7 +2,10 @@ import { X, RotateCcw, Plus, Edit3, Trash2 } from "lucide-react";
 import { useState, useEffect } from "react";
 import { ThemeToggle } from "./chat/ThemeToggle";
 import { useTheme } from "../hooks/useTheme";
-import { useAgentConfig, type Agent } from "../hooks/useAgentConfig";
+import { useAgentConfig, type Agent, type AgentAvatar, type AgentRole } from "../hooks/useAgentConfig";
+import { AvatarPicker } from "./settings/AvatarPicker";
+import { SystemPromptEditor } from "./settings/SystemPromptEditor";
+import { ToolPermissionPicker } from "./settings/ToolPermissionPicker";
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -382,12 +385,26 @@ interface AgentFormModalProps {
 }
 
 function AgentFormModal({ agent, onSave, onCancel }: AgentFormModalProps) {
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<{
+    name: string;
+    workingDirectory: string;
+    description: string;
+    color: string;
+    apiEndpoint: string;
+    avatar?: AgentAvatar;
+    systemPrompt?: string;
+    allowedTools?: string[];
+    role?: AgentRole;
+  }>({
     name: agent?.name || '',
     workingDirectory: agent?.workingDirectory || '',
     description: agent?.description || '',
     color: agent?.color || 'bg-blue-500',
-    apiEndpoint: agent?.apiEndpoint || 'https://api.claudecode.run',
+    apiEndpoint: agent?.apiEndpoint || 'http://localhost:8080',
+    avatar: agent?.avatar,
+    systemPrompt: agent?.systemPrompt,
+    allowedTools: agent?.allowedTools,
+    role: agent?.role,
   });
 
   const handleSave = () => {
@@ -450,7 +467,7 @@ function AgentFormModal({ agent, onSave, onCancel }: AgentFormModalProps) {
         }}
         onClick={(e) => e.stopPropagation()}
       >
-        <h3 
+        <h3
           style={{
             fontSize: "16px",
             fontWeight: 600,
@@ -460,6 +477,17 @@ function AgentFormModal({ agent, onSave, onCancel }: AgentFormModalProps) {
         >
           {agent ? 'Edit Agent' : 'Add New Agent'}
         </h3>
+
+        {/* Avatar Picker */}
+        <div style={{ marginBottom: "16px" }}>
+          <label style={{ display: "block", fontSize: "14px", fontWeight: 500, color: "var(--claude-text-primary)", marginBottom: "6px" }}>
+            Avatar
+          </label>
+          <AvatarPicker
+            value={formData.avatar}
+            onChange={(avatar) => setFormData(prev => ({ ...prev, avatar }))}
+          />
+        </div>
 
         <div style={{ marginBottom: "16px" }}>
           <label style={{ display: "block", fontSize: "14px", fontWeight: 500, color: "var(--claude-text-primary)", marginBottom: "6px" }}>
@@ -512,7 +540,7 @@ function AgentFormModal({ agent, onSave, onCancel }: AgentFormModalProps) {
             type="url"
             value={formData.apiEndpoint}
             onChange={(e) => setFormData(prev => ({ ...prev, apiEndpoint: e.target.value }))}
-            placeholder="https://api.claudecode.run"
+            placeholder="http://localhost:8080"
             style={{
               width: "100%",
               padding: "8px 12px",
@@ -546,6 +574,26 @@ function AgentFormModal({ agent, onSave, onCancel }: AgentFormModalProps) {
           />
         </div>
 
+        {/* System Prompt & Persona */}
+        <div style={{ marginBottom: "16px" }}>
+          <SystemPromptEditor
+            value={formData.systemPrompt}
+            onChange={(prompt) => setFormData(prev => ({ ...prev, systemPrompt: prompt }))}
+            role={formData.role}
+            onRoleChange={(role) => setFormData(prev => ({ ...prev, role }))}
+          />
+        </div>
+
+        {/* Tool Permissions */}
+        <div style={{ marginBottom: "16px" }}>
+          <label style={{ display: "block", fontSize: "14px", fontWeight: 500, color: "var(--claude-text-primary)", marginBottom: "6px" }}>
+            Tool Permissions
+          </label>
+          <ToolPermissionPicker
+            value={formData.allowedTools}
+            onChange={(tools) => setFormData(prev => ({ ...prev, allowedTools: tools }))}
+          />
+        </div>
 
         <div style={{ display: "flex", gap: "8px", marginTop: "24px" }}>
           <button

--- a/frontend/src/components/chat/ChatMessages.tsx
+++ b/frontend/src/components/chat/ChatMessages.tsx
@@ -91,7 +91,7 @@ function EmptyState() {
   return (
     <div className="empty-state">
       <div className="empty-state-icon">👨‍💻</div>
-      <h3>Welcome to Agentrooms</h3>
+      <h3>Welcome to Claude Ops-Deck</h3>
       <p>Assign a task or @mention agents to start</p>
     </div>
   );

--- a/frontend/src/components/native/AgentDetailView.tsx
+++ b/frontend/src/components/native/AgentDetailView.tsx
@@ -17,6 +17,7 @@ import { PermissionDialog } from "../PermissionDialog";
 import { getChatUrl } from "../../config/api";
 import type { StreamingContext } from "../../hooks/streaming/useMessageProcessor";
 import { debugStreamingConnection, debugStreamingChunk, debugStreamingPerformance, warnProxyBuffering } from "../../utils/streamingDebug";
+import { AgentAvatar } from "../shared/AgentAvatar";
 
 interface AgentDetailViewProps {
   agentId: string;
@@ -45,28 +46,6 @@ interface AgentDetailViewProps {
   getOrCreateAgentSession: (agentId: string) => any;
   loadHistoricalMessages: (messages: any[], sessionId: string, agentId?: string, useAgentRoom?: boolean) => void;
 }
-
-const getAgentColor = (agentId: string) => {
-  // Generate consistent colors based on agent ID
-  const colors = [
-    "#3b82f6", // blue
-    "#ef4444", // red  
-    "#10b981", // green
-    "#f59e0b", // yellow
-    "#8b5cf6", // purple
-    "#ec4899", // pink
-    "#06b6d4", // cyan
-    "#84cc16", // lime
-  ];
-  
-  // Create a simple hash from the agent ID
-  let hash = 0;
-  for (let i = 0; i < agentId.length; i++) {
-    hash = agentId.charCodeAt(i) + ((hash << 5) - hash);
-  }
-  
-  return colors[Math.abs(hash) % colors.length];
-};
 
 export function AgentDetailView({ 
   agentId,
@@ -323,6 +302,8 @@ export function AgentDetailView({
         sessionId: agentSessionId || undefined,
         requestId,
         workingDirectory: agent.workingDirectory,
+        systemPrompt: agent.systemPrompt,
+        allowedTools: agent.allowedTools?.length ? agent.allowedTools : undefined,
         claudeAuth: claudeSession ? {
           accessToken: claudeSession.accessToken,
           refreshToken: claudeSession.refreshToken,
@@ -337,7 +318,9 @@ export function AgentDetailView({
           description: agent.description,
           workingDirectory: agent.workingDirectory,
           apiEndpoint: agent.apiEndpoint,
-          isOrchestrator: agent.isOrchestrator
+          isOrchestrator: agent.isOrchestrator,
+          systemPrompt: agent.systemPrompt,
+          role: agent.role,
         })),
       };
 
@@ -486,6 +469,8 @@ export function AgentDetailView({
         sessionId: agentSessionId || undefined,
         requestId,
         workingDirectory: targetAgent.workingDirectory,
+        systemPrompt: targetAgent.systemPrompt,
+        allowedTools: targetAgent.allowedTools?.length ? targetAgent.allowedTools : undefined,
         claudeAuth: claudeSession ? {
           accessToken: claudeSession.accessToken,
           refreshToken: claudeSession.refreshToken,
@@ -500,7 +485,9 @@ export function AgentDetailView({
           description: agent.description,
           workingDirectory: agent.workingDirectory,
           apiEndpoint: agent.apiEndpoint,
-          isOrchestrator: agent.isOrchestrator
+          isOrchestrator: agent.isOrchestrator,
+          systemPrompt: agent.systemPrompt,
+          role: agent.role,
         })),
       };
 
@@ -679,8 +666,6 @@ export function AgentDetailView({
   const isActive = agentSessionId !== null;
   const status = isActive ? "Active" : "Idle";
 
-  const agentColor = getAgentColor(agent.id);
-
   const copyPath = () => {
     navigator.clipboard.writeText(agent.workingDirectory);
   };
@@ -690,12 +675,7 @@ export function AgentDetailView({
       <div className="agent-detail-content" style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}>
         {/* Agent Header with Configuration */}
         <div className="agent-detail-header" style={{ flexShrink: 0 }}>
-          <div 
-            className="agent-detail-icon"
-            style={{ backgroundColor: agentColor }}
-          >
-            {agent.name.charAt(0).toUpperCase()}
-          </div>
+          <AgentAvatar size="lg" agent={agent} showBadge />
           <div className="agent-detail-info" style={{ flex: 1 }}>
             <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
               <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>

--- a/frontend/src/components/native/AgentHubPage.tsx
+++ b/frontend/src/components/native/AgentHubPage.tsx
@@ -19,9 +19,14 @@ import { useRemoteAgentHistory } from "../../hooks/useRemoteAgentHistory";
 import { useClaudeAuth } from "../../hooks/useClaudeAuth";
 import type { StreamingContext } from "../../hooks/streaming/useMessageProcessor";
 import { debugStreamingConnection, debugStreamingChunk, debugStreamingPerformance, warnProxyBuffering } from "../../utils/streamingDebug";
+import { useAgentInteractions } from "../../hooks/useAgentInteractions";
+import { AgentNetworkMap } from "../visualization/AgentNetworkMap";
+import "../../components/visualization/visualization.css";
 
 export function AgentHubPage() {
   const [currentMode, setCurrentMode] = useState<"group" | "agent">("group");
+  const [hubView, setHubView] = useState<"chat" | "map">("chat");
+  const { trackInteraction, getGraph } = useAgentInteractions();
   
   useTheme(); // For theme switching support
   const { processStreamLine } = useClaudeStreaming();
@@ -343,6 +348,8 @@ export function AgentHubPage() {
         sessionId: sessionToUse || undefined,
         requestId,
         workingDirectory: currentAgent.workingDirectory,
+        systemPrompt: currentAgent.systemPrompt,
+        allowedTools: currentAgent.allowedTools?.length ? currentAgent.allowedTools : undefined,
         claudeAuth: claudeSession ? {
           accessToken: claudeSession.accessToken,
           refreshToken: claudeSession.refreshToken,
@@ -357,7 +364,9 @@ export function AgentHubPage() {
           description: agent.description,
           workingDirectory: agent.workingDirectory,
           apiEndpoint: agent.apiEndpoint,
-          isOrchestrator: agent.isOrchestrator
+          isOrchestrator: agent.isOrchestrator,
+          systemPrompt: agent.systemPrompt,
+          role: agent.role,
         })),
       };
 
@@ -528,6 +537,8 @@ export function AgentHubPage() {
         sessionId: stepSessionId,
         requestId,
         workingDirectory: targetAgent.workingDirectory,
+        systemPrompt: targetAgent.systemPrompt,
+        allowedTools: targetAgent.allowedTools?.length ? targetAgent.allowedTools : undefined,
         claudeAuth: claudeSession ? {
           accessToken: claudeSession.accessToken,
           refreshToken: claudeSession.refreshToken,
@@ -542,7 +553,9 @@ export function AgentHubPage() {
           description: agent.description,
           workingDirectory: agent.workingDirectory,
           apiEndpoint: agent.apiEndpoint,
-          isOrchestrator: agent.isOrchestrator
+          isOrchestrator: agent.isOrchestrator,
+          systemPrompt: agent.systemPrompt,
+          role: agent.role,
         })),
       };
 
@@ -763,29 +776,78 @@ export function AgentHubPage() {
         ) : (
           /* Chat Interface */
           <>
-            {/* Messages Area */}
-            <div className="messages-container">
-              <ChatMessages 
-                messages={currentMode === "group" ? getAgentRoomContext().messages : messages} 
-                isLoading={isLoading} 
-                onExecuteStep={handleExecuteStep}
-                onExecutePlan={handleExecutePlan}
-                currentAgentId={activeAgentId || undefined}
-              />
+            {/* View Toggle */}
+            <div style={{
+              display: "flex",
+              gap: "2px",
+              padding: "4px",
+              margin: "0 12px",
+              background: "var(--claude-input-bg)",
+              borderRadius: "6px",
+              border: "1px solid var(--claude-border)",
+              width: "fit-content",
+            }}>
+              {(["chat", "map"] as const).map((view) => (
+                <button
+                  key={view}
+                  onClick={() => setHubView(view)}
+                  style={{
+                    padding: "4px 12px",
+                    borderRadius: "4px",
+                    fontSize: "11px",
+                    fontWeight: 600,
+                    textTransform: "capitalize",
+                    color: hubView === view ? "var(--claude-text-primary)" : "var(--claude-text-muted)",
+                    background: hubView === view ? "var(--claude-sidebar-hover)" : "transparent",
+                    border: "none",
+                    cursor: "pointer",
+                    transition: "all 0.15s ease",
+                  }}
+                >
+                  {view}
+                </button>
+              ))}
             </div>
 
-            {/* Chat Input */}
-            <ChatInput
-              input={input}
-              isLoading={isLoading}
-              currentRequestId={currentRequestId}
-              activeAgentId={activeAgentId}
-              currentMode={currentMode}
-              lastUsedAgentId={lastUsedAgentId}
-              onInputChange={setInput}
-              onSubmit={handleSendMessage}
-              onAbort={handleAbort}
-            />
+            {hubView === "map" ? (
+              /* Agent Network Map */
+              <div className="messages-container" style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>
+                <AgentNetworkMap
+                  agents={agents}
+                  graph={getGraph(agents)}
+                  onAgentClick={(agentId) => {
+                    switchToAgent(agentId);
+                    setCurrentMode("agent");
+                  }}
+                />
+              </div>
+            ) : (
+              <>
+                {/* Messages Area */}
+                <div className="messages-container">
+                  <ChatMessages
+                    messages={currentMode === "group" ? getAgentRoomContext().messages : messages}
+                    isLoading={isLoading}
+                    onExecuteStep={handleExecuteStep}
+                    onExecutePlan={handleExecutePlan}
+                    currentAgentId={activeAgentId || undefined}
+                  />
+                </div>
+
+                {/* Chat Input */}
+                <ChatInput
+                  input={input}
+                  isLoading={isLoading}
+                  currentRequestId={currentRequestId}
+                  activeAgentId={activeAgentId}
+                  currentMode={currentMode}
+                  lastUsedAgentId={lastUsedAgentId}
+                  onInputChange={setInput}
+                  onSubmit={handleSendMessage}
+                  onAbort={handleAbort}
+                />
+              </>
+            )}
           </>
         )}
       </div>

--- a/frontend/src/components/native/ChatHeader.tsx
+++ b/frontend/src/components/native/ChatHeader.tsx
@@ -1,23 +1,13 @@
-import { Users, User, MoreHorizontal, Download, Trash2 } from "lucide-react";
+import { Users, MoreHorizontal, Download, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useAgentConfig } from "../../hooks/useAgentConfig";
+import { AgentAvatar } from "../shared/AgentAvatar";
 
 interface ChatHeaderProps {
   currentMode: "group" | "agent";
   activeAgentId: string | null;
   onModeToggle: () => void;
 }
-
-const getAgentColor = (agentId: string) => {
-  // Map agent IDs to CSS color variables, with fallback
-  const colorMap: Record<string, string> = {
-    "readymojo-admin": "var(--agent-admin)",
-    "readymojo-api": "var(--agent-api)", 
-    "readymojo-web": "var(--agent-web)",
-    "peakmojo-kit": "var(--agent-kit)",
-  };
-  return colorMap[agentId] || "var(--claude-text-accent)";
-};
 
 export function ChatHeader({ currentMode, activeAgentId }: ChatHeaderProps) {
   const [showMenu, setShowMenu] = useState(false);
@@ -42,12 +32,16 @@ export function ChatHeader({ currentMode, activeAgentId }: ChatHeaderProps) {
           </>
         ) : (
           <>
-            <div 
-              className="chat-header-icon"
-              style={{ backgroundColor: currentAgent ? getAgentColor(currentAgent.id) : "var(--claude-border)" }}
-            >
-              <User size={12} />
-            </div>
+            {currentAgent ? (
+              <AgentAvatar size="md" agent={currentAgent} />
+            ) : (
+              <div
+                className="chat-header-icon"
+                style={{ backgroundColor: "var(--claude-border)" }}
+              >
+                <Users size={12} />
+              </div>
+            )}
             <div className="chat-header-info">
               <h2>{currentAgent?.name || "Select Agent"}</h2>
               <p>Agent Details</p>

--- a/frontend/src/components/native/ChatInput.tsx
+++ b/frontend/src/components/native/ChatInput.tsx
@@ -17,9 +17,9 @@ interface ChatInputProps {
 const getAgentColor = (agentId: string) => {
   // Map agent IDs to CSS color variables, with fallback
   const colorMap: Record<string, string> = {
-    "readymojo-admin": "var(--agent-admin)",
-    "readymojo-api": "var(--agent-api)", 
-    "readymojo-web": "var(--agent-web)",
+    "project-admin": "var(--agent-admin)",
+    "project-api": "var(--agent-api)",
+    "project-web": "var(--agent-web)",
     "peakmojo-kit": "var(--agent-kit)",
   };
   return colorMap[agentId] || "var(--claude-text-accent)";

--- a/frontend/src/components/native/MessageBubble.tsx
+++ b/frontend/src/components/native/MessageBubble.tsx
@@ -1,22 +1,12 @@
 import { User, Bot } from "lucide-react";
 import type { ChatMessage } from "../../types";
 import { useAgentConfig } from "../../hooks/useAgentConfig";
+import { AgentAvatar } from "../shared/AgentAvatar";
 
 interface MessageBubbleProps {
   message: ChatMessage;
   isLast?: boolean;
 }
-
-const getAgentColor = (agentId: string) => {
-  // Map agent IDs to CSS color variables, with fallback
-  const colorMap: Record<string, string> = {
-    "readymojo-admin": "var(--agent-admin)",
-    "readymojo-api": "var(--agent-api)", 
-    "readymojo-web": "var(--agent-web)",
-    "peakmojo-kit": "var(--agent-kit)",
-  };
-  return colorMap[agentId] || "var(--claude-text-accent)";
-};
 
 export function MessageBubble({ message, isLast = false }: MessageBubbleProps) {
   const isUser = message.role === "user";
@@ -34,14 +24,13 @@ export function MessageBubble({ message, isLast = false }: MessageBubbleProps) {
   return (
     <div className={`message-item animate-in ${isLast ? 'last' : ''}`}>
       {/* Avatar */}
-      <div 
-        className={`message-avatar ${isUser ? 'user' : ''}`}
-        style={!isUser && agent ? { 
-          backgroundColor: getAgentColor(agent.id)
-        } : {}}
-      >
-        {isUser ? <User size={14} /> : <Bot size={14} />}
-      </div>
+      {!isUser && agent ? (
+        <AgentAvatar size="md" agent={agent} />
+      ) : (
+        <div className={`message-avatar ${isUser ? 'user' : ''}`}>
+          {isUser ? <User size={14} /> : <Bot size={14} />}
+        </div>
+      )}
 
       {/* Message Content */}
       <div className="message-content">

--- a/frontend/src/components/native/Sidebar.tsx
+++ b/frontend/src/components/native/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { MessageCircle, Users, Settings } from "lucide-react";
 import { useState } from "react";
 import { useAgentConfig } from "../../hooks/useAgentConfig";
+import { AgentAvatar } from "../shared/AgentAvatar";
 import { SettingsModal } from "../SettingsModal";
 import { AuthButton } from "../auth/AuthButton";
 
@@ -12,17 +13,6 @@ interface SidebarProps {
   currentMode: "group" | "agent";
   onModeChange: (mode: "group" | "agent") => void;
 }
-
-const getAgentColor = (agentId: string) => {
-  // Map agent IDs to CSS color variables, with fallback
-  const colorMap: Record<string, string> = {
-    "readymojo-admin": "var(--agent-admin)",
-    "readymojo-api": "var(--agent-api)", 
-    "readymojo-web": "var(--agent-web)",
-    "peakmojo-kit": "var(--agent-kit)",
-  };
-  return colorMap[agentId] || "var(--claude-text-accent)";
-};
 
 export function Sidebar({ 
   activeAgentId, 
@@ -45,8 +35,8 @@ export function Sidebar({
             <MessageCircle size={14} />
           </div>
           <div className="sidebar-brand-text">
-            <h1>Agentrooms</h1>
-            <p>Multi-Agent Workspace</p>
+            <h1>Claude Ops-Deck</h1>
+            <p>AI Agent Mission Control</p>
           </div>
         </div>
 
@@ -85,10 +75,7 @@ export function Sidebar({
               className={`sidebar-agent-item ${isActive ? "active" : ""}`}
             >
               {/* Agent Indicator */}
-              <div 
-                className="sidebar-agent-dot"
-                style={{ backgroundColor: getAgentColor(agent.id) }}
-              />
+              <AgentAvatar size="sm" agent={agent} />
               
               {/* Agent Info */}
               <div className="sidebar-agent-info">

--- a/frontend/src/components/settings/AvatarPicker.tsx
+++ b/frontend/src/components/settings/AvatarPicker.tsx
@@ -1,0 +1,194 @@
+import { useState } from "react";
+import { LUCIDE_ICON_MAP } from "../shared/AgentAvatar";
+import type { AgentAvatar } from "../../hooks/useAgentConfig";
+
+const EMOJI_OPTIONS = [
+  "\u{1F916}", "\u2699\uFE0F", "\u{1F6E1}\uFE0F", "\u{1F9E0}", "\u{1F680}",
+  "\u{1F50D}", "\u{1F4BB}", "\u{1F528}", "\u26A1", "\u{1F3AF}",
+  "\u{1F4DA}", "\u{1F512}", "\u{1F310}", "\u{1F41B}", "\u{1F4A1}",
+  "\u{1F52D}", "\u2764\uFE0F", "\u2B50", "\u{1F525}", "\u{1F308}",
+];
+
+type TabId = "letter" | "emoji" | "icon";
+
+interface AvatarPickerProps {
+  value: AgentAvatar | undefined;
+  onChange: (avatar: AgentAvatar) => void;
+}
+
+export function AvatarPicker({ value, onChange }: AvatarPickerProps) {
+  const currentTab: TabId = value?.type === "emoji"
+    ? "emoji"
+    : value?.type === "lucide-icon"
+    ? "icon"
+    : "letter";
+
+  const [activeTab, setActiveTab] = useState<TabId>(currentTab);
+
+  const tabs: { id: TabId; label: string }[] = [
+    { id: "letter", label: "Letter" },
+    { id: "emoji", label: "Emoji" },
+    { id: "icon", label: "Icon" },
+  ];
+
+  const iconNames = Object.keys(LUCIDE_ICON_MAP);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+      {/* Tab bar */}
+      <div
+        style={{
+          display: "flex",
+          gap: "2px",
+          background: "var(--claude-input-bg)",
+          borderRadius: "6px",
+          padding: "2px",
+          border: "1px solid var(--claude-border)",
+        }}
+      >
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            style={{
+              flex: 1,
+              padding: "4px 8px",
+              borderRadius: "4px",
+              fontSize: "11px",
+              fontWeight: 600,
+              color:
+                activeTab === tab.id
+                  ? "var(--claude-text-primary)"
+                  : "var(--claude-text-muted)",
+              background:
+                activeTab === tab.id
+                  ? "var(--claude-sidebar-hover)"
+                  : "transparent",
+              border: "none",
+              cursor: "pointer",
+              transition: "all 0.15s ease",
+            }}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      {activeTab === "letter" && (
+        <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+          <input
+            type="text"
+            maxLength={2}
+            value={value?.type === "letter" ? value.value : ""}
+            placeholder="A"
+            onChange={(e) =>
+              onChange({ type: "letter", value: e.target.value.toUpperCase() })
+            }
+            style={{
+              padding: "6px 10px",
+              borderRadius: "6px",
+              border: "1px solid var(--claude-border)",
+              background: "var(--claude-input-bg)",
+              color: "var(--claude-text-primary)",
+              fontSize: "13px",
+              fontWeight: 600,
+              textAlign: "center",
+              width: "60px",
+            }}
+          />
+          <span
+            style={{
+              fontSize: "11px",
+              color: "var(--claude-text-muted)",
+            }}
+          >
+            1-2 characters
+          </span>
+        </div>
+      )}
+
+      {activeTab === "emoji" && (
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(7, 1fr)",
+            gap: "4px",
+          }}
+        >
+          {EMOJI_OPTIONS.map((emoji) => (
+            <button
+              key={emoji}
+              onClick={() => onChange({ type: "emoji", value: emoji })}
+              style={{
+                width: "32px",
+                height: "32px",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                borderRadius: "6px",
+                fontSize: "16px",
+                border:
+                  value?.type === "emoji" && value.value === emoji
+                    ? "2px solid var(--claude-text-accent)"
+                    : "1px solid var(--claude-border)",
+                background:
+                  value?.type === "emoji" && value.value === emoji
+                    ? "var(--claude-sidebar-hover)"
+                    : "var(--claude-input-bg)",
+                cursor: "pointer",
+                transition: "all 0.15s ease",
+              }}
+            >
+              {emoji}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {activeTab === "icon" && (
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(7, 1fr)",
+            gap: "4px",
+          }}
+        >
+          {iconNames.map((name) => {
+            const Icon = LUCIDE_ICON_MAP[name];
+            const isSelected =
+              value?.type === "lucide-icon" && value.value === name;
+            return (
+              <button
+                key={name}
+                onClick={() => onChange({ type: "lucide-icon", value: name })}
+                title={name}
+                style={{
+                  width: "32px",
+                  height: "32px",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  borderRadius: "6px",
+                  border: isSelected
+                    ? "2px solid var(--claude-text-accent)"
+                    : "1px solid var(--claude-border)",
+                  background: isSelected
+                    ? "var(--claude-sidebar-hover)"
+                    : "var(--claude-input-bg)",
+                  color: isSelected
+                    ? "var(--claude-text-accent)"
+                    : "var(--claude-text-secondary)",
+                  cursor: "pointer",
+                  transition: "all 0.15s ease",
+                }}
+              >
+                <Icon size={14} />
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/settings/SystemPromptEditor.tsx
+++ b/frontend/src/components/settings/SystemPromptEditor.tsx
@@ -1,0 +1,112 @@
+import { PERSONA_TEMPLATES, getTemplateByRole } from "../../config/personaTemplates";
+import type { AgentRole } from "../../hooks/useAgentConfig";
+
+interface SystemPromptEditorProps {
+  value: string | undefined;
+  onChange: (prompt: string) => void;
+  role?: AgentRole;
+  onRoleChange?: (role: AgentRole) => void;
+}
+
+const MAX_CHARS = 2000;
+
+export function SystemPromptEditor({
+  value,
+  onChange,
+  role,
+  onRoleChange,
+}: SystemPromptEditorProps) {
+  const charCount = (value || "").length;
+
+  const handlePresetChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const selectedRole = e.target.value as AgentRole;
+    if (selectedRole === "custom") {
+      onRoleChange?.("custom");
+      return;
+    }
+    const template = getTemplateByRole(selectedRole);
+    if (template) {
+      onRoleChange?.(template.role);
+      onChange(template.systemPrompt);
+    }
+  };
+
+  const currentSelection = role || "custom";
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+      <label
+        style={{
+          fontSize: "13px",
+          fontWeight: 500,
+          color: "var(--claude-text-primary)",
+        }}
+      >
+        Persona Preset
+      </label>
+      <select
+        value={currentSelection}
+        onChange={handlePresetChange}
+        style={{
+          padding: "8px 12px",
+          borderRadius: "6px",
+          border: "1px solid var(--claude-border)",
+          backgroundColor: "var(--claude-input-bg)",
+          color: "var(--claude-text-primary)",
+          fontSize: "13px",
+          outline: "none",
+          cursor: "pointer",
+        }}
+      >
+        {PERSONA_TEMPLATES.map((t) => (
+          <option key={t.role} value={t.role}>
+            {t.label} — {t.description}
+          </option>
+        ))}
+        <option value="custom">Custom</option>
+      </select>
+
+      <label
+        style={{
+          fontSize: "13px",
+          fontWeight: 500,
+          color: "var(--claude-text-primary)",
+          marginTop: "4px",
+        }}
+      >
+        System Prompt
+      </label>
+      <textarea
+        value={value || ""}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Enter a system prompt to customize this agent's personality and behavior..."
+        rows={8}
+        style={{
+          padding: "10px 12px",
+          borderRadius: "6px",
+          border: "1px solid var(--claude-border)",
+          backgroundColor: "var(--claude-input-bg)",
+          color: "var(--claude-text-primary)",
+          fontSize: "13px",
+          lineHeight: "1.5",
+          resize: "vertical",
+          outline: "none",
+          fontFamily: "inherit",
+          minHeight: "120px",
+        }}
+      />
+      <div
+        style={{
+          fontSize: "11px",
+          color:
+            charCount > MAX_CHARS
+              ? "#ef4444"
+              : "var(--claude-text-secondary, #888)",
+          textAlign: "right",
+        }}
+      >
+        {charCount} / {MAX_CHARS} characters
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/ToolPermissionPicker.tsx
+++ b/frontend/src/components/settings/ToolPermissionPicker.tsx
@@ -1,0 +1,198 @@
+import { useState, useEffect } from "react";
+import {
+  CLAUDE_CODE_TOOLS,
+  TOOL_PRESETS,
+  getToolsByCategory,
+  matchPreset,
+} from "../../config/toolPresets";
+
+interface ToolPermissionPickerProps {
+  value: string[] | undefined; // undefined = all tools (no restriction)
+  onChange: (tools: string[] | undefined) => void;
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  file: "File Operations",
+  search: "Search",
+  system: "System",
+  web: "Web",
+};
+
+const CATEGORIES = ["file", "search", "system", "web"] as const;
+
+export function ToolPermissionPicker({ value, onChange }: ToolPermissionPickerProps) {
+  const [selectedPreset, setSelectedPreset] = useState(() => matchPreset(value));
+  const [customTools, setCustomTools] = useState<Set<string>>(() =>
+    new Set(value ?? CLAUDE_CODE_TOOLS.map(t => t.name))
+  );
+
+  // Sync preset selection when value prop changes externally
+  useEffect(() => {
+    const matched = matchPreset(value);
+    setSelectedPreset(matched);
+    if (matched === "custom" && value !== undefined) {
+      setCustomTools(new Set(value));
+    }
+  }, [value]);
+
+  const handlePresetChange = (presetId: string) => {
+    setSelectedPreset(presetId);
+
+    const preset = TOOL_PRESETS.find(p => p.id === presetId);
+    if (!preset) return;
+
+    if (presetId === "full") {
+      onChange(undefined);
+    } else if (presetId === "custom") {
+      // Switch to custom — emit current custom selection
+      const tools = Array.from(customTools);
+      onChange(tools.length > 0 ? tools : []);
+    } else if (preset.tools) {
+      onChange([...preset.tools]);
+    }
+  };
+
+  const handleToolToggle = (toolName: string) => {
+    const next = new Set(customTools);
+    if (next.has(toolName)) {
+      next.delete(toolName);
+    } else {
+      next.add(toolName);
+    }
+    setCustomTools(next);
+    onChange(next.size > 0 ? Array.from(next) : []);
+  };
+
+  return (
+    <div>
+      {/* Preset radio group */}
+      <div style={{ display: "flex", flexDirection: "column", gap: "8px", marginBottom: "16px" }}>
+        {TOOL_PRESETS.map(preset => (
+          <label
+            key={preset.id}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "10px",
+              padding: "10px 12px",
+              borderRadius: "8px",
+              border: `1px solid ${selectedPreset === preset.id ? "var(--claude-text-accent)" : "var(--claude-border)"}`,
+              background: selectedPreset === preset.id ? "var(--claude-input-bg)" : "transparent",
+              cursor: "pointer",
+              transition: "all 0.15s ease",
+            }}
+          >
+            <input
+              type="radio"
+              name="tool-preset"
+              value={preset.id}
+              checked={selectedPreset === preset.id}
+              onChange={() => handlePresetChange(preset.id)}
+              style={{ accentColor: "var(--claude-text-accent)" }}
+            />
+            <div style={{ flex: 1 }}>
+              <div
+                style={{
+                  fontSize: "13px",
+                  fontWeight: 500,
+                  color: "var(--claude-text-primary)",
+                }}
+              >
+                {preset.label}
+              </div>
+              <div
+                style={{
+                  fontSize: "11px",
+                  color: "var(--claude-text-muted)",
+                  marginTop: "2px",
+                }}
+              >
+                {preset.description}
+              </div>
+            </div>
+          </label>
+        ))}
+      </div>
+
+      {/* Custom tool checklist */}
+      {selectedPreset === "custom" && (
+        <div
+          style={{
+            border: "1px solid var(--claude-border)",
+            borderRadius: "8px",
+            padding: "12px",
+            background: "var(--claude-input-bg)",
+          }}
+        >
+          {CATEGORIES.map(category => {
+            const tools = getToolsByCategory(category);
+            if (tools.length === 0) return null;
+
+            return (
+              <div key={category} style={{ marginBottom: "12px" }}>
+                <div
+                  style={{
+                    fontSize: "11px",
+                    fontWeight: 600,
+                    textTransform: "uppercase",
+                    letterSpacing: "0.05em",
+                    color: "var(--claude-text-muted)",
+                    marginBottom: "6px",
+                  }}
+                >
+                  {CATEGORY_LABELS[category]}
+                </div>
+                <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                  {tools.map(tool => (
+                    <label
+                      key={tool.name}
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "8px",
+                        padding: "6px 8px",
+                        borderRadius: "6px",
+                        cursor: "pointer",
+                        transition: "background 0.15s ease",
+                      }}
+                      onMouseEnter={e => {
+                        e.currentTarget.style.background = "var(--claude-sidebar-hover)";
+                      }}
+                      onMouseLeave={e => {
+                        e.currentTarget.style.background = "transparent";
+                      }}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={customTools.has(tool.name)}
+                        onChange={() => handleToolToggle(tool.name)}
+                        style={{ accentColor: "var(--claude-text-accent)" }}
+                      />
+                      <span
+                        style={{
+                          fontSize: "13px",
+                          fontWeight: 500,
+                          color: "var(--claude-text-primary)",
+                        }}
+                      >
+                        {tool.name}
+                      </span>
+                      <span
+                        style={{
+                          fontSize: "11px",
+                          color: "var(--claude-text-muted)",
+                        }}
+                      >
+                        {tool.description}
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/shared/AgentAvatar.tsx
+++ b/frontend/src/components/shared/AgentAvatar.tsx
@@ -1,0 +1,101 @@
+import {
+  Code, Terminal, Shield, Eye, Wrench, Cpu, Database, Globe,
+  Zap, Brain, Search, FileCode, GitBranch, Layers, Palette,
+  Rocket, Bug, Lock, Compass, BookOpen, Cog, Heart,
+  Star, Lightbulb, Wand2, Telescope, Hammer, Gauge, Users,
+  type LucideIcon,
+} from "lucide-react";
+import type { Agent } from "../../hooks/useAgentConfig";
+import { getAgentColor } from "../../utils/agentColors";
+
+/** Map of supported lucide icon names to their components */
+export const LUCIDE_ICON_MAP: Record<string, LucideIcon> = {
+  Code, Terminal, Shield, Eye, Wrench, Cpu, Database, Globe,
+  Zap, Brain, Search, FileCode, GitBranch, Layers, Palette,
+  Rocket, Bug, Lock, Compass, BookOpen, Cog, Heart,
+  Star, Lightbulb, Wand2, Telescope, Hammer, Gauge, Users,
+};
+
+const SIZE_CONFIG = {
+  sm:  { px: 24, fontSize: 11, iconSize: 12 },
+  md:  { px: 28, fontSize: 13, iconSize: 14 },
+  lg:  { px: 48, fontSize: 20, iconSize: 22 },
+} as const;
+
+interface AgentAvatarProps {
+  agent: Agent;
+  size: 'sm' | 'md' | 'lg';
+  showBadge?: boolean;
+  className?: string;
+}
+
+export function AgentAvatar({ agent, size, showBadge = false, className = '' }: AgentAvatarProps) {
+  const { px, fontSize, iconSize } = SIZE_CONFIG[size];
+  const bgColor = getAgentColor(agent);
+
+  const containerStyle: React.CSSProperties = {
+    width: px,
+    height: px,
+    minWidth: px,
+    borderRadius: '50%',
+    backgroundColor: bgColor,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    color: '#fff',
+    fontSize,
+    fontWeight: 600,
+    lineHeight: 1,
+    position: 'relative',
+    overflow: showBadge ? 'visible' : 'hidden',
+  };
+
+  const renderContent = () => {
+    const avatar = agent.avatar;
+
+    // Emoji avatar
+    if (avatar?.type === 'emoji' && avatar.value) {
+      return <span style={{ fontSize: fontSize + 2, lineHeight: 1 }}>{avatar.value}</span>;
+    }
+
+    // Lucide icon avatar
+    if (avatar?.type === 'lucide-icon' && avatar.value) {
+      const IconComponent = LUCIDE_ICON_MAP[avatar.value];
+      if (IconComponent) {
+        return <IconComponent size={iconSize} />;
+      }
+    }
+
+    // Letter fallback (default)
+    const letter = avatar?.type === 'letter' && avatar.value
+      ? avatar.value
+      : agent.name.charAt(0).toUpperCase();
+    return <span>{letter}</span>;
+  };
+
+  return (
+    <div
+      className={`agent-avatar agent-avatar-${size} ${className}`}
+      style={containerStyle}
+      title={agent.name}
+    >
+      {renderContent()}
+      {showBadge && agent.role && agent.role !== 'custom' && (
+        <span
+          className="agent-avatar-role-dot"
+          style={{
+            position: 'absolute',
+            bottom: -2,
+            right: -2,
+            width: 10,
+            height: 10,
+            borderRadius: '50%',
+            backgroundColor: bgColor,
+            border: '2px solid var(--claude-bg)',
+            filter: 'brightness(1.3)',
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/shared/RoleBadge.tsx
+++ b/frontend/src/components/shared/RoleBadge.tsx
@@ -1,0 +1,30 @@
+import type { AgentRole } from "../../hooks/useAgentConfig";
+
+const ROLE_COLORS: Record<AgentRole, { bg: string; text: string }> = {
+  architect: { bg: "rgba(59,130,246,0.15)", text: "#3b82f6" },
+  sprinter:  { bg: "rgba(16,185,129,0.15)", text: "#10b981" },
+  reviewer:  { bg: "rgba(245,158,11,0.15)", text: "#f59e0b" },
+  mentor:    { bg: "rgba(139,92,246,0.15)",  text: "#8b5cf6" },
+  guardian:  { bg: "rgba(239,68,68,0.15)",   text: "#ef4444" },
+  custom:    { bg: "rgba(107,114,128,0.15)", text: "#6b7280" },
+};
+
+interface RoleBadgeProps {
+  role: AgentRole;
+}
+
+export function RoleBadge({ role }: RoleBadgeProps) {
+  const colors = ROLE_COLORS[role] ?? ROLE_COLORS.custom;
+
+  return (
+    <span
+      className="role-badge"
+      style={{
+        backgroundColor: colors.bg,
+        color: colors.text,
+      }}
+    >
+      {role}
+    </span>
+  );
+}

--- a/frontend/src/components/visualization/AgentNetworkMap.tsx
+++ b/frontend/src/components/visualization/AgentNetworkMap.tsx
@@ -1,0 +1,198 @@
+import { useState } from "react";
+import type { Agent } from "../../hooks/useAgentConfig";
+import type { AgentGraph } from "../../types/agentGraph";
+import "./visualization.css";
+
+interface AgentNetworkMapProps {
+  agents: Agent[];
+  graph: AgentGraph;
+  onAgentClick?: (agentId: string) => void;
+}
+
+const NODE_RADIUS = 22;
+
+const STATUS_COLORS: Record<string, string> = {
+  idle: '#22c55e',
+  active: '#f59e0b',
+  busy: '#ef4444',
+};
+
+export function AgentNetworkMap({ agents, graph, onAgentClick }: AgentNetworkMapProps) {
+  const [hoveredNode, setHoveredNode] = useState<string | null>(null);
+  const [tooltipPos, setTooltipPos] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
+
+  const maxWeight = Math.max(1, ...graph.edges.map(e => e.weight));
+
+  const getStrokeWidth = (weight: number) => {
+    return 1 + (weight / maxWeight) * 4; // min 1, max 5
+  };
+
+  const getOpacity = (weight: number) => {
+    return 0.3 + (weight / maxWeight) * 0.7; // min 0.3, max 1.0
+  };
+
+  const getInitial = (agentId: string) => {
+    const agent = agents.find(a => a.id === agentId);
+    if (!agent) return '?';
+    if (agent.avatar?.type === 'letter' && agent.avatar.value) return agent.avatar.value;
+    return agent.name.charAt(0).toUpperCase();
+  };
+
+  const getNode = (id: string) => graph.nodes.find(n => n.id === id);
+
+  const handleMouseEnter = (nodeId: string, event: React.MouseEvent<SVGGElement>) => {
+    setHoveredNode(nodeId);
+    const svgRect = (event.currentTarget.closest('svg') as SVGSVGElement)?.getBoundingClientRect();
+    if (svgRect) {
+      const node = getNode(nodeId);
+      if (node) {
+        const scaleX = svgRect.width / 500;
+        const scaleY = svgRect.height / 400;
+        setTooltipPos({
+          x: node.position.x * scaleX,
+          y: node.position.y * scaleY - NODE_RADIUS - 8,
+        });
+      }
+    }
+  };
+
+  const hoveredNodeData = hoveredNode ? getNode(hoveredNode) : null;
+
+  return (
+    <div className="agent-network-map" style={{ position: 'relative' }}>
+      <svg
+        width="100%"
+        height="400"
+        viewBox="0 0 500 400"
+        style={{ display: 'block' }}
+      >
+        <defs>
+          <marker
+            id="arrowhead"
+            markerWidth="8"
+            markerHeight="6"
+            refX="8"
+            refY="3"
+            orient="auto"
+          >
+            <polygon
+              points="0 0, 8 3, 0 6"
+              fill="var(--claude-border, #333)"
+            />
+          </marker>
+        </defs>
+
+        {/* Edges */}
+        {graph.edges.map(edge => {
+          const fromNode = getNode(edge.from);
+          const toNode = getNode(edge.to);
+          if (!fromNode || !toNode) return null;
+
+          // Shorten line to avoid overlapping node circles
+          const dx = toNode.position.x - fromNode.position.x;
+          const dy = toNode.position.y - fromNode.position.y;
+          const dist = Math.sqrt(dx * dx + dy * dy);
+          if (dist === 0) return null;
+          const ux = dx / dist;
+          const uy = dy / dist;
+
+          const x1 = fromNode.position.x + ux * (NODE_RADIUS + 2);
+          const y1 = fromNode.position.y + uy * (NODE_RADIUS + 2);
+          const x2 = toNode.position.x - ux * (NODE_RADIUS + 10);
+          const y2 = toNode.position.y - uy * (NODE_RADIUS + 10);
+
+          return (
+            <line
+              key={edge.id}
+              className="edge"
+              x1={x1}
+              y1={y1}
+              x2={x2}
+              y2={y2}
+              stroke="var(--claude-border, #333)"
+              strokeWidth={getStrokeWidth(edge.weight)}
+              opacity={getOpacity(edge.weight)}
+              markerEnd={edge.type === 'pipeline' ? 'url(#arrowhead)' : undefined}
+            />
+          );
+        })}
+
+        {/* Nodes */}
+        {graph.nodes.map(node => (
+          <g
+            key={node.id}
+            className="node"
+            onClick={() => onAgentClick?.(node.id)}
+            onMouseEnter={(e) => handleMouseEnter(node.id, e)}
+            onMouseLeave={() => setHoveredNode(null)}
+            style={{ cursor: 'pointer' }}
+          >
+            {/* Orchestrator ring */}
+            {node.isOrchestrator && (
+              <circle
+                cx={node.position.x}
+                cy={node.position.y}
+                r={NODE_RADIUS + 4}
+                fill="none"
+                stroke={node.color}
+                strokeWidth={2}
+                strokeDasharray="4 2"
+                opacity={0.5}
+              />
+            )}
+
+            {/* Main circle */}
+            <circle
+              cx={node.position.x}
+              cy={node.position.y}
+              r={NODE_RADIUS}
+              fill={node.color}
+            />
+
+            {/* Initial letter */}
+            <text
+              x={node.position.x}
+              y={node.position.y}
+              textAnchor="middle"
+              dominantBaseline="central"
+              fill="#fff"
+              fontSize={14}
+              fontWeight={600}
+              style={{ pointerEvents: 'none', userSelect: 'none' }}
+            >
+              {getInitial(node.id)}
+            </text>
+
+            {/* Status indicator dot */}
+            <circle
+              cx={node.position.x + NODE_RADIUS * 0.65}
+              cy={node.position.y + NODE_RADIUS * 0.65}
+              r={5}
+              fill={STATUS_COLORS[node.status] || STATUS_COLORS.idle}
+              stroke="var(--claude-bg, #1a1a2e)"
+              strokeWidth={2}
+            />
+          </g>
+        ))}
+      </svg>
+
+      {/* Tooltip */}
+      {hoveredNodeData && (
+        <div
+          className="tooltip"
+          style={{
+            left: tooltipPos.x,
+            top: tooltipPos.y,
+            transform: 'translate(-50%, -100%)',
+          }}
+        >
+          <div className="tooltip-name">{hoveredNodeData.name}</div>
+          {hoveredNodeData.role && (
+            <div className="tooltip-detail">Role: {hoveredNodeData.role}</div>
+          )}
+          <div className="tooltip-detail">Status: {hoveredNodeData.status}</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/visualization/ExecutionFlowViz.tsx
+++ b/frontend/src/components/visualization/ExecutionFlowViz.tsx
@@ -1,0 +1,114 @@
+import type { Agent } from "../../hooks/useAgentConfig";
+import { getAgentColor } from "../../utils/agentColors";
+import "./visualization.css";
+
+interface ExecutionStep {
+  id: string;
+  agent: string;
+  message: string;
+  status: 'pending' | 'in_progress' | 'completed' | 'failed';
+  dependencies?: string[];
+  result?: string;
+}
+
+interface ExecutionFlowVizProps {
+  steps: ExecutionStep[];
+  agents: Agent[];
+  onStepClick?: (stepId: string) => void;
+}
+
+const STATUS_CONFIG: Record<string, { color: string; label: string }> = {
+  pending:     { color: 'var(--claude-border, #666)',         label: 'Pending' },
+  in_progress: { color: 'var(--claude-text-accent, #7c8aff)', label: 'In Progress' },
+  completed:   { color: 'var(--claude-success, #22c55e)',      label: 'Completed' },
+  failed:      { color: 'var(--claude-error, #ef4444)',        label: 'Failed' },
+};
+
+export function ExecutionFlowViz({ steps, agents, onStepClick }: ExecutionFlowVizProps) {
+  const getAgent = (agentId: string) => agents.find(a => a.id === agentId);
+
+  const getAgentInitial = (agentId: string) => {
+    const agent = getAgent(agentId);
+    if (!agent) return '?';
+    if (agent.avatar?.type === 'letter' && agent.avatar.value) return agent.avatar.value;
+    return agent.name.charAt(0).toUpperCase();
+  };
+
+  const getColor = (agentId: string) => {
+    const agent = getAgent(agentId);
+    if (!agent) return '#666';
+    return getAgentColor(agent);
+  };
+
+  return (
+    <div className="execution-flow">
+      {steps.map((step, index) => {
+        const statusCfg = STATUS_CONFIG[step.status] || STATUS_CONFIG.pending;
+        const isActive = step.status === 'in_progress';
+        const showConnector = index < steps.length - 1;
+
+        return (
+          <div key={step.id}>
+            {/* Step card */}
+            <div
+              className={`execution-flow-step ${isActive ? 'status-active' : ''}`}
+              onClick={() => onStepClick?.(step.id)}
+              style={
+                step.status === 'completed'
+                  ? { borderColor: 'var(--claude-success, #22c55e)', borderLeftWidth: 3 }
+                  : step.status === 'failed'
+                  ? { borderColor: 'var(--claude-error, #ef4444)', borderLeftWidth: 3 }
+                  : undefined
+              }
+            >
+              {/* Agent avatar */}
+              <div
+                className="execution-flow-step-avatar"
+                style={{ backgroundColor: getColor(step.agent) }}
+              >
+                {getAgentInitial(step.agent)}
+              </div>
+
+              {/* Content */}
+              <div className="execution-flow-step-content">
+                <div className="execution-flow-step-message">{step.message}</div>
+                <div
+                  className="execution-flow-step-status"
+                  style={{ color: statusCfg.color }}
+                >
+                  <span
+                    className="execution-flow-step-status-dot"
+                    style={{ backgroundColor: statusCfg.color }}
+                  />
+                  {statusCfg.label}
+                </div>
+                {step.result && (
+                  <div className="execution-flow-step-result">{step.result}</div>
+                )}
+              </div>
+            </div>
+
+            {/* Connector to next step */}
+            {showConnector && (
+              <div className="execution-flow-connector">
+                <svg width="24" height="24" viewBox="0 0 24 24">
+                  <path
+                    d="M12 0 C12 0, 12 12, 12 24"
+                    fill="none"
+                    stroke="var(--claude-border, #333)"
+                    strokeWidth={1.5}
+                    strokeDasharray={steps[index + 1]?.dependencies?.includes(step.id) ? 'none' : '4 3'}
+                  />
+                  <polygon
+                    points="8 20, 12 24, 16 20"
+                    fill="var(--claude-border, #333)"
+                  />
+                </svg>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/visualization/visualization.css
+++ b/frontend/src/components/visualization/visualization.css
@@ -1,0 +1,138 @@
+/* Agent Network Map */
+.agent-network-map {
+  width: 100%;
+  position: relative;
+}
+
+.agent-network-map .node {
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.agent-network-map .node:hover {
+  transform: scale(1.1);
+}
+
+.agent-network-map .edge {
+  transition: opacity 0.3s ease;
+}
+
+.agent-network-map .tooltip {
+  position: absolute;
+  padding: 6px 10px;
+  border-radius: 6px;
+  background: var(--claude-bg, #1a1a2e);
+  border: 1px solid var(--claude-border, #333);
+  color: var(--claude-text-primary, #e0e0e0);
+  font-size: 12px;
+  pointer-events: none;
+  z-index: 10;
+  white-space: nowrap;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.agent-network-map .tooltip-name {
+  font-weight: 600;
+  margin-bottom: 2px;
+}
+
+.agent-network-map .tooltip-detail {
+  opacity: 0.7;
+  font-size: 11px;
+}
+
+/* Execution Flow */
+.execution-flow {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  position: relative;
+  padding: 16px 0;
+}
+
+.execution-flow-step {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 1px solid var(--claude-border, #333);
+  background: var(--claude-bg, #1a1a2e);
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease;
+  position: relative;
+  z-index: 1;
+}
+
+.execution-flow-step:hover {
+  border-color: var(--claude-text-accent, #7c8aff);
+  background: rgba(124, 138, 255, 0.05);
+}
+
+.execution-flow-step-avatar {
+  width: 32px;
+  height: 32px;
+  min-width: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.execution-flow-step-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.execution-flow-step-message {
+  font-size: 13px;
+  color: var(--claude-text-primary, #e0e0e0);
+  margin-bottom: 4px;
+  line-height: 1.4;
+}
+
+.execution-flow-step-status {
+  font-size: 11px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.execution-flow-step-status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.execution-flow-step-result {
+  font-size: 11px;
+  color: var(--claude-text-primary, #e0e0e0);
+  opacity: 0.6;
+  margin-top: 4px;
+  line-height: 1.3;
+}
+
+.execution-flow-connector {
+  position: relative;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.execution-flow-connector svg {
+  overflow: visible;
+}
+
+@keyframes pulse-active {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}
+
+.status-active {
+  animation: pulse-active 1.5s ease-in-out infinite;
+}

--- a/frontend/src/config/agents.ts
+++ b/frontend/src/config/agents.ts
@@ -1,11 +1,7 @@
-export interface Agent {
-  id: string;
-  name: string;
-  workingDirectory: string;
-  color: string;
-  description: string;
-  isOrchestrator?: boolean; // Indicates if this agent orchestrates others
-}
+// Re-export Agent type from the canonical source
+export type { Agent, AgentAvatar, AgentAvatarType, AgentRole } from "../hooks/useAgentConfig";
+
+import type { Agent } from "../hooks/useAgentConfig";
 
 export const PREDEFINED_AGENTS: Agent[] = [
   {
@@ -14,6 +10,7 @@ export const PREDEFINED_AGENTS: Agent[] = [
     workingDirectory: "/tmp/orchestrator",
     color: "bg-gradient-to-r from-blue-500 to-purple-500",
     description: "Intelligent orchestrator that coordinates multi-agent workflows",
+    apiEndpoint: "http://localhost:8080",
     isOrchestrator: true
   }
 ];

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -13,15 +13,15 @@ export const API_CONFIG = {
   },
 } as const;
 
-// Helper function to get full API URL using orchestrator agent configuration
-export const getApiUrl = (endpoint: string, orchestratorEndpoint?: string) => {
-  // In development, check if we should use local backend
-  if (import.meta.env.DEV && import.meta.env.VITE_USE_LOCAL_API === "true") {
-    return endpoint; // Use Vite proxy
+// Helper function to get full API URL using agent endpoint configuration
+export const getApiUrl = (endpoint: string, agentEndpoint?: string) => {
+  // In development, Vite proxies /api to the local backend — use relative paths
+  if (import.meta.env.DEV) {
+    return endpoint;
   }
-  
-  // Use orchestrator endpoint if provided, otherwise fallback to default
-  const baseUrl = orchestratorEndpoint || "https://api.claudecode.run";
+
+  // In production (Electron), use the agent's configured endpoint
+  const baseUrl = agentEndpoint || "http://localhost:8080";
   return `${baseUrl}${endpoint}`;
 };
 

--- a/frontend/src/config/personaTemplates.ts
+++ b/frontend/src/config/personaTemplates.ts
@@ -1,0 +1,93 @@
+import type { AgentRole } from "../hooks/useAgentConfig";
+
+export interface PersonaTemplate {
+  role: AgentRole;
+  label: string;
+  description: string;
+  systemPrompt: string;
+  suggestedTools: string[];
+}
+
+export const PERSONA_TEMPLATES: PersonaTemplate[] = [
+  {
+    role: "architect",
+    label: "Architect",
+    description: "System design focus, verbose, writes docs. Thinks about architecture, patterns, scalability.",
+    systemPrompt: `You are a software architect. Focus on system design, architectural patterns, and scalability.
+
+When reviewing or writing code:
+- Think about the big picture first: how components interact, data flows, and system boundaries
+- Document your design decisions with rationale
+- Consider maintainability, extensibility, and separation of concerns
+- Suggest patterns (e.g., repository, factory, observer) where appropriate
+- Write thorough documentation for public APIs and architectural boundaries
+- Be verbose in explanations — clarity is more important than brevity`,
+    suggestedTools: ["Read", "Glob", "Grep", "Write"],
+  },
+  {
+    role: "sprinter",
+    label: "Sprinter",
+    description: "Terse, fast implementation, follows existing patterns. Minimal explanations, just code.",
+    systemPrompt: `You are a fast, focused implementer. Write code quickly and follow existing patterns.
+
+Rules:
+- Minimal explanations — just produce working code
+- Follow existing conventions in the codebase exactly
+- Prefer editing existing files over creating new ones
+- No over-engineering or premature abstractions
+- If something works, ship it
+- Only comment code where the logic is non-obvious`,
+    suggestedTools: [],
+  },
+  {
+    role: "reviewer",
+    label: "Reviewer",
+    description: "Read-only analysis, finds bugs, suggests fixes. Never modifies files directly.",
+    systemPrompt: `You are a code reviewer. Analyze code for bugs, performance issues, and maintainability problems.
+
+Rules:
+- NEVER modify files directly — only suggest changes
+- Look for: bugs, race conditions, security issues, performance bottlenecks
+- Check for proper error handling and edge cases
+- Verify that code follows the project's existing conventions
+- Provide specific, actionable feedback with file paths and line numbers
+- Prioritize issues by severity: critical > major > minor > style`,
+    suggestedTools: ["Read", "Glob", "Grep"],
+  },
+  {
+    role: "mentor",
+    label: "Mentor",
+    description: "Explains everything, teaches, asks clarifying questions. Educational tone.",
+    systemPrompt: `You are a patient, knowledgeable mentor. Your goal is to teach and explain, not just solve.
+
+Approach:
+- Explain your reasoning step by step
+- When writing code, explain WHY you chose this approach over alternatives
+- Ask clarifying questions when requirements are ambiguous
+- Point out learning opportunities and relevant concepts
+- Reference documentation or best practices where helpful
+- Encourage good habits: testing, documentation, clean code
+- Use analogies to make complex concepts accessible`,
+    suggestedTools: [],
+  },
+  {
+    role: "guardian",
+    label: "Guardian",
+    description: "Security-first analysis, flags vulnerabilities, checks for OWASP issues.",
+    systemPrompt: `You are a security-focused code analyst. Your primary concern is identifying and preventing vulnerabilities.
+
+Focus areas:
+- OWASP Top 10: injection, broken auth, sensitive data exposure, XXE, broken access control, misconfiguration, XSS, insecure deserialization, vulnerable components, insufficient logging
+- Input validation and sanitization at all system boundaries
+- Authentication and authorization patterns
+- Secrets management (no hardcoded keys, tokens, or passwords)
+- Dependency vulnerabilities and supply chain risks
+- Secure defaults and principle of least privilege
+- Flag any code that handles user input, file paths, or external data without proper validation`,
+    suggestedTools: ["Read", "Glob", "Grep", "Write"],
+  },
+];
+
+export function getTemplateByRole(role: AgentRole): PersonaTemplate | undefined {
+  return PERSONA_TEMPLATES.find((t) => t.role === role);
+}

--- a/frontend/src/config/toolPresets.ts
+++ b/frontend/src/config/toolPresets.ts
@@ -1,0 +1,91 @@
+export interface ToolInfo {
+  name: string;
+  description: string;
+  category: 'file' | 'search' | 'system' | 'web';
+}
+
+export interface ToolPreset {
+  id: string;
+  label: string;
+  description: string;
+  tools: string[] | null; // null = all tools (no restriction)
+}
+
+export const CLAUDE_CODE_TOOLS: ToolInfo[] = [
+  // File Operations
+  { name: 'Read', description: 'Read file contents', category: 'file' },
+  { name: 'Write', description: 'Create or overwrite files', category: 'file' },
+  { name: 'Edit', description: 'Edit existing files', category: 'file' },
+  { name: 'NotebookEdit', description: 'Edit Jupyter notebooks', category: 'file' },
+
+  // Search
+  { name: 'Glob', description: 'Find files by pattern', category: 'search' },
+  { name: 'Grep', description: 'Search file contents', category: 'search' },
+
+  // System
+  { name: 'Bash', description: 'Execute shell commands', category: 'system' },
+  { name: 'Agent', description: 'Launch sub-agents', category: 'system' },
+
+  // Web
+  { name: 'WebFetch', description: 'Fetch web content', category: 'web' },
+  { name: 'WebSearch', description: 'Search the web', category: 'web' },
+];
+
+export const TOOL_PRESETS: ToolPreset[] = [
+  {
+    id: 'full',
+    label: 'Full Access',
+    description: 'All tools available (no restrictions)',
+    tools: null,
+  },
+  {
+    id: 'read-only',
+    label: 'Read Only',
+    description: 'Can read and search but not modify files',
+    tools: ['Read', 'Glob', 'Grep', 'WebFetch', 'WebSearch'],
+  },
+  {
+    id: 'read-write',
+    label: 'Read & Write',
+    description: 'File operations and search, no shell access',
+    tools: ['Read', 'Write', 'Edit', 'Glob', 'Grep', 'NotebookEdit'],
+  },
+  {
+    id: 'custom',
+    label: 'Custom',
+    description: 'Select individual tools',
+    tools: null, // Custom selection managed by component
+  },
+];
+
+export function getPresetById(id: string): ToolPreset | undefined {
+  return TOOL_PRESETS.find(preset => preset.id === id);
+}
+
+export function getToolsByCategory(category: string): ToolInfo[] {
+  return CLAUDE_CODE_TOOLS.filter(tool => tool.category === category);
+}
+
+export function matchPreset(tools: string[] | undefined): string {
+  // undefined means no restriction = full access
+  if (tools === undefined) {
+    return 'full';
+  }
+
+  // Check against each non-custom preset with a defined tool list
+  for (const preset of TOOL_PRESETS) {
+    if (preset.id === 'custom' || preset.tools === null) continue;
+
+    const presetTools = [...preset.tools].sort();
+    const inputTools = [...tools].sort();
+
+    if (
+      presetTools.length === inputTools.length &&
+      presetTools.every((t, i) => t === inputTools[i])
+    ) {
+      return preset.id;
+    }
+  }
+
+  return 'custom';
+}

--- a/frontend/src/hooks/chat/useChatState.ts
+++ b/frontend/src/hooks/chat/useChatState.ts
@@ -71,7 +71,7 @@ export function useChatState() {
     if (activeAgentId) return activeAgentId;
     if (lastUsedAgentId) return lastUsedAgentId;
     // Fallback to first available agent
-    return "readymojo-admin"; // Default to admin agent
+    return "project-admin"; // Default to admin agent
   }, [activeAgentId, lastUsedAgentId]);
 
   // Add message - supports both orchestrator and individual agent modes

--- a/frontend/src/hooks/useAgentConfig.ts
+++ b/frontend/src/hooks/useAgentConfig.ts
@@ -1,5 +1,14 @@
 import { useState, useEffect } from "react";
 
+export type AgentAvatarType = 'letter' | 'emoji' | 'lucide-icon';
+
+export interface AgentAvatar {
+  type: AgentAvatarType;
+  value: string;
+}
+
+export type AgentRole = 'architect' | 'sprinter' | 'reviewer' | 'mentor' | 'guardian' | 'custom';
+
 export interface Agent {
   id: string;
   name: string;
@@ -8,6 +17,10 @@ export interface Agent {
   description: string;
   apiEndpoint: string;
   isOrchestrator?: boolean;
+  avatar?: AgentAvatar;
+  systemPrompt?: string;
+  allowedTools?: string[];
+  role?: AgentRole;
 }
 
 export interface AgentSystemConfig {
@@ -21,7 +34,7 @@ const DEFAULT_AGENTS: Agent[] = [
     workingDirectory: "/tmp/orchestrator",
     color: "bg-gradient-to-r from-blue-500 to-purple-500",
     description: "Intelligent orchestrator that coordinates multi-agent workflows",
-    apiEndpoint: "https://api.claudecode.run",
+    apiEndpoint: "http://localhost:8080",
     isOrchestrator: true
   }
 ];
@@ -74,16 +87,32 @@ export function useAgentConfig() {
         // Simply use the saved config, merging with any new default agents
         const existingAgentIds = new Set(parsedConfig.agents?.map((a: Agent) => a.id) || []);
         const newDefaultAgents = DEFAULT_CONFIG.agents.filter(agent => !existingAgentIds.has(agent.id));
-        
+
+        // Migrate existing agents: backfill new optional fields with defaults
+        let needsMigration = false;
+        const migratedAgents = (parsedConfig.agents || []).map((agent: Agent) => {
+          const migrated = { ...agent };
+          if (!migrated.avatar) {
+            migrated.avatar = { type: 'letter' as AgentAvatarType, value: migrated.name.charAt(0).toUpperCase() };
+            needsMigration = true;
+          }
+          if (migrated.role === undefined) {
+            migrated.role = migrated.isOrchestrator ? 'architect' as AgentRole : 'custom' as AgentRole;
+            needsMigration = true;
+          }
+          // systemPrompt and allowedTools default to undefined (no backfill needed)
+          return migrated;
+        });
+
         const mergedConfig = {
-          agents: [...(parsedConfig.agents || []), ...newDefaultAgents]
+          agents: [...migratedAgents, ...newDefaultAgents]
         };
         console.log("🔀 Merged config:", mergedConfig);
         setConfig(mergedConfig);
-        
-        // Save the merged config if new agents were added
-        if (newDefaultAgents.length > 0) {
-          console.log("💾 Saving merged config with new agents:", newDefaultAgents);
+
+        // Save the merged config if new agents were added or migration occurred
+        if (newDefaultAgents.length > 0 || needsMigration) {
+          console.log("💾 Saving merged config with new agents/migration:", { newDefaultAgents: newDefaultAgents.length, needsMigration });
           localStorage.setItem(STORAGE_KEY, JSON.stringify(mergedConfig));
         }
       } else {

--- a/frontend/src/hooks/useAgentInteractions.ts
+++ b/frontend/src/hooks/useAgentInteractions.ts
@@ -1,0 +1,79 @@
+import { useState, useCallback } from "react";
+import type { Agent } from "./useAgentConfig";
+import type { AgentGraph, AgentNode, AgentEdge } from "../types/agentGraph";
+import { getAgentColor } from "../utils/agentColors";
+
+const CANVAS_WIDTH = 500;
+const CANVAS_HEIGHT = 400;
+const CENTER_X = CANVAS_WIDTH / 2;
+const CENTER_Y = CANVAS_HEIGHT / 2;
+const RADIUS = 150;
+
+export function useAgentInteractions() {
+  const [interactions, setInteractions] = useState<Map<string, number>>(new Map());
+
+  const trackInteraction = useCallback((fromAgentId: string, toAgentId: string) => {
+    setInteractions(prev => {
+      const next = new Map(prev);
+      const key = `${fromAgentId}:${toAgentId}`;
+      next.set(key, (next.get(key) || 0) + 1);
+      return next;
+    });
+  }, []);
+
+  const getGraph = useCallback((agents: Agent[]): AgentGraph => {
+    const orchestrator = agents.find(a => a.isOrchestrator);
+    const others = agents.filter(a => !a.isOrchestrator);
+
+    const nodes: AgentNode[] = agents.map((agent, _i) => {
+      let position: { x: number; y: number };
+
+      if (agent.isOrchestrator) {
+        position = { x: CENTER_X, y: CENTER_Y };
+      } else {
+        const idx = others.indexOf(agent);
+        const count = others.length;
+        const angle = (2 * Math.PI * idx) / count - Math.PI / 2;
+        position = {
+          x: CENTER_X + RADIUS * Math.cos(angle),
+          y: CENTER_Y + RADIUS * Math.sin(angle),
+        };
+      }
+
+      return {
+        id: agent.id,
+        name: agent.name,
+        color: getAgentColor(agent),
+        role: agent.role,
+        position,
+        status: 'idle' as const,
+        isOrchestrator: agent.isOrchestrator,
+      };
+    });
+
+    const edges: AgentEdge[] = [];
+    interactions.forEach((weight, key) => {
+      const [from, to] = key.split(':');
+      const fromExists = agents.some(a => a.id === from);
+      const toExists = agents.some(a => a.id === to);
+      if (fromExists && toExists) {
+        const isPipeline = from === orchestrator?.id || to === orchestrator?.id;
+        edges.push({
+          id: `edge-${from}-${to}`,
+          from,
+          to,
+          type: isPipeline ? 'pipeline' : 'collaborative',
+          weight,
+        });
+      }
+    });
+
+    return { nodes, edges };
+  }, [interactions]);
+
+  const resetInteractions = useCallback(() => {
+    setInteractions(new Map());
+  }, []);
+
+  return { trackInteraction, getGraph, resetInteractions };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,7 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
-/* ReadyMojo Orange Theme - Dark Mode (Default) */
+/* Claude Ops-Deck Theme - Dark Mode (Default) */
 :root {
   /* Main Background - Rich dark with warm undertones */
   --claude-main-bg: #1a1612;
@@ -16,7 +16,7 @@
   --claude-text-primary: #ffffff;
   --claude-text-secondary: #e6d5c4;
   --claude-text-muted: #b8a896;
-  --claude-text-accent: #ff6b35; /* Primary ReadyMojo orange */
+  --claude-text-accent: #ff6b35; /* Primary Ops-Deck orange */
   
   /* Message Colors - Warmer tones */
   --claude-message-bg: #2b251a;
@@ -46,7 +46,7 @@
   --claude-error: #ff4d4f;
 }
 
-/* ReadyMojo Orange Theme - Light Mode */
+/* Claude Ops-Deck Theme - Light Mode */
 [data-theme="light"] {
   /* Main Background - Clean light with warm orange undertones */
   --claude-main-bg: #faf8f6;
@@ -733,6 +733,22 @@ input, textarea {
   font-size: 14px;
   color: var(--claude-text-secondary);
   margin: 0;
+}
+
+/* Agent Avatar */
+.agent-avatar { transition: transform 0.15s ease; }
+.agent-avatar:hover { transform: scale(1.05); }
+
+/* Role Badge */
+.role-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
 }
 
 /* Animations */

--- a/frontend/src/types/agentGraph.ts
+++ b/frontend/src/types/agentGraph.ts
@@ -1,0 +1,22 @@
+export interface AgentNode {
+  id: string;
+  name: string;
+  color: string;
+  role?: string;
+  position: { x: number; y: number };
+  status: 'idle' | 'active' | 'busy';
+  isOrchestrator?: boolean;
+}
+
+export interface AgentEdge {
+  id: string;
+  from: string;
+  to: string;
+  type: 'pipeline' | 'collaborative';
+  weight: number; // message count
+}
+
+export interface AgentGraph {
+  nodes: AgentNode[];
+  edges: AgentEdge[];
+}

--- a/frontend/src/utils/agentColors.ts
+++ b/frontend/src/utils/agentColors.ts
@@ -1,0 +1,51 @@
+/**
+ * Unified agent color utility.
+ * Single source of truth for agent color derivation, replacing
+ * inconsistent methods across Sidebar, ChatHeader, MessageComponents,
+ * MessageBubble, and AgentDetailView.
+ */
+
+const AGENT_PALETTE = [
+  '#3b82f6', // blue
+  '#ef4444', // red
+  '#10b981', // emerald
+  '#f59e0b', // amber
+  '#8b5cf6', // violet
+  '#ec4899', // pink
+  '#06b6d4', // cyan
+  '#84cc16', // lime
+  '#f97316', // orange
+  '#14b8a6', // teal
+  '#a855f7', // purple
+  '#e11d48', // rose
+] as const;
+
+/**
+ * Deterministic hash for a string → palette index.
+ * Uses djb2 algorithm for good distribution.
+ */
+function hashString(str: string): number {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash) + str.charCodeAt(i);
+  }
+  return Math.abs(hash);
+}
+
+/**
+ * Returns a consistent hex color for an agent.
+ *
+ * Priority:
+ * 1. If agent.color is a hex value (#...), use it directly
+ * 2. Otherwise, hash-select from the 12-color palette
+ */
+export function getAgentColor(agent: { id: string; color?: string }): string {
+  // If the agent has an explicit hex color, use it
+  if (agent.color && agent.color.startsWith('#')) {
+    return agent.color;
+  }
+  // Hash-select from palette
+  return AGENT_PALETTE[hashString(agent.id) % AGENT_PALETTE.length];
+}
+
+export { AGENT_PALETTE };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,9 @@
       "name": "agentrooms",
       "version": "0.0.7",
       "hasInstallScript": true,
-      "dependencies": {
-        "electron": "^37.4.0"
-      },
       "devDependencies": {
+        "concurrently": "^9.2.1",
+        "electron": "^37.4.0",
         "electron-builder": "^25.1.8"
       }
     },
@@ -68,6 +67,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
       "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
@@ -643,6 +643,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -655,6 +656,7 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
       "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "defer-to-connect": "^2.0.0"
@@ -677,6 +679,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
       "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-cache-semantics": "*",
@@ -709,12 +712,14 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
       "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -731,6 +736,7 @@
       "version": "22.18.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.0.tgz",
       "integrity": "sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -752,6 +758,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -769,6 +776,7 @@
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -842,6 +850,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1008,7 +1017,6 @@
       "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "archiver-utils": "^2.1.0",
         "async": "^3.2.4",
@@ -1028,7 +1036,6 @@
       "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.0",
@@ -1051,7 +1058,6 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -1067,8 +1073,7 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/archiver-utils/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -1076,7 +1081,6 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -1221,6 +1225,7 @@
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -1264,6 +1269,7 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -1441,6 +1447,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
       "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.6.0"
@@ -1450,6 +1457,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
       "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clone-response": "^1.0.2",
@@ -1611,6 +1619,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
       "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^1.0.0"
@@ -1688,7 +1697,6 @@
       "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-crc32": "^0.2.13",
         "crc32-stream": "^4.0.2",
@@ -1705,6 +1713,47 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
     },
     "node_modules/config-file-ts": {
       "version": "0.2.8-rc1",
@@ -1805,7 +1854,6 @@
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -1819,7 +1867,6 @@
       "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
@@ -1847,6 +1894,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1864,6 +1912,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -1879,6 +1928,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1904,6 +1954,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1913,6 +1964,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1931,6 +1983,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1976,6 +2029,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -2009,6 +2063,7 @@
       "integrity": "sha512-NoXo6Liy2heSklTI5OIZbCgXC1RzrDQsZkeEwXhdOro3FT1VBOvbubvscdPnjVuQ4AMwwv61oaH96AbiYg9EnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "25.1.8",
         "builder-util": "25.1.7",
@@ -2157,6 +2212,7 @@
       "version": "37.4.0",
       "resolved": "https://registry.npmjs.org/electron/-/electron-37.4.0.tgz",
       "integrity": "sha512-HhsSdWowE5ODOeWNc/323Ug2C52mq/TqNBG+4uMeOA3G2dMXNc/nfyi0RYu1rJEgiaJLEjtHveeZZaYRYFsFCQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -2203,7 +2259,6 @@
       "integrity": "sha512-2ntkJ+9+0GFP6nAISiMabKt6eqBB0kX1QqHNWFWAXgi0VULKGisM46luRFpIBiU3u/TDmhZMM8tzvo2Abn3ayg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "25.1.8",
         "archiver": "^5.3.1",
@@ -2217,7 +2272,6 @@
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -2233,7 +2287,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -2247,7 +2300,6 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2366,6 +2418,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -2375,6 +2428,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2391,7 +2445,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2401,7 +2455,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2440,6 +2494,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -2457,6 +2512,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -2477,6 +2533,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "debug": "^4.1.1",
@@ -2522,6 +2579,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
@@ -2612,13 +2670,13 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
       "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -2733,6 +2791,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
@@ -2783,6 +2842,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
       "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -2801,6 +2861,7 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -2814,6 +2875,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2831,7 +2893,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2844,6 +2906,7 @@
       "version": "11.8.6",
       "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
       "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
@@ -2869,6 +2932,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -2885,6 +2949,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2960,6 +3025,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/http-proxy-agent": {
@@ -2980,6 +3046,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
       "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "quick-lru": "^5.1.1",
@@ -3183,8 +3250,7 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/isbinaryfile": {
       "version": "5.0.4",
@@ -3278,6 +3344,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -3291,6 +3358,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -3311,6 +3379,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
@@ -3320,6 +3389,7 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -3338,7 +3408,6 @@
       "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.5"
       },
@@ -3352,7 +3421,6 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -3368,8 +3436,7 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -3377,7 +3444,6 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -3394,40 +3460,35 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -3450,6 +3511,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3552,6 +3614,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
       "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3621,6 +3684,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -3766,6 +3830,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -3896,7 +3961,6 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3905,6 +3969,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -3934,6 +3999,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3944,6 +4010,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -3993,6 +4060,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4110,6 +4178,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/plist": {
@@ -4132,13 +4201,13 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -4169,6 +4238,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
       "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -4189,6 +4259,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4231,7 +4302,6 @@
       "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "minimatch": "^5.1.0"
       }
@@ -4242,7 +4312,6 @@
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -4253,7 +4322,6 @@
       "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -4293,12 +4361,14 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/responselike": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
       "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lowercase-keys": "^2.0.0"
@@ -4352,6 +4422,7 @@
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
       "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -4364,6 +4435,16 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -4415,6 +4496,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4424,6 +4506,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -4431,6 +4514,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
       "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4471,6 +4555,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -4601,7 +4698,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/ssri": {
@@ -4699,6 +4796,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
       "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.1.0"
@@ -4744,7 +4842,6 @@
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -4835,6 +4932,16 @@
         "tmp": "^0.2.0"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
@@ -4845,10 +4952,18 @@
         "utf8-byte-length": "^1.0.1"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/type-fest": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
       "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "optional": true,
       "engines": {
@@ -4876,6 +4991,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unique-filename": {
@@ -4908,6 +5024,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
@@ -5030,6 +5147,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/xmlbuilder": {
@@ -5092,6 +5210,7 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
@@ -5117,7 +5236,6 @@
       "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "archiver-utils": "^3.0.4",
         "compress-commons": "^4.1.2",
@@ -5133,7 +5251,6 @@
       "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob": "^7.2.3",
         "graceful-fs": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.7",
   "description": "AI Agent Mission Control - Multi-Agent Development Workspace",
   "main": "electron/main.js",
-  "author": "Claude Ops-Deck Team",
+  "author": "Axiom-Labs",
   "scripts": {
     "dev": "concurrently -k -n backend,frontend -c blue,green \"npm run dev:backend\" \"npm run dev:frontend\"",
     "dev:frontend": "cd frontend && npm run dev",
@@ -31,7 +31,7 @@
     "postinstall": "cd frontend && npm install && cd ../backend && npm install"
   },
   "build": {
-    "appId": "com.claude-ops-deck.app",
+    "appId": "com.axiom-labs.claude-ops-deck",
     "productName": "Claude Ops-Deck",
     "electronVersion": "32.2.7",
     "directories": {

--- a/package.json
+++ b/package.json
@@ -1,16 +1,27 @@
 {
-  "name": "agentrooms",
-  "productName": "Agentrooms",
+  "name": "claude-ops-deck",
+  "productName": "Claude Ops-Deck",
   "version": "0.0.7",
-  "description": "Multi-Agent Programming Collaboration Tool",
+  "description": "AI Agent Mission Control - Multi-Agent Development Workspace",
   "main": "electron/main.js",
-  "author": "Agentrooms Team",
+  "author": "Claude Ops-Deck Team",
   "scripts": {
-    "electron": "electron .",
-    "electron:dev": "NODE_ENV=development electron .",
+    "dev": "concurrently -k -n backend,frontend -c blue,green \"npm run dev:backend\" \"npm run dev:frontend\"",
+    "dev:frontend": "cd frontend && npm run dev",
+    "dev:backend": "cd backend && npm run dev",
+    "dev:frontend:only": "cd frontend && npm run dev",
+    "dev:electron": "concurrently -k -n backend,frontend,electron -c blue,green,yellow \"npm run dev:backend\" \"npm run dev:frontend\" \"sleep 3 && NODE_ENV=development electron .\"",
+    "install:all": "npm install && cd frontend && npm install && cd ../backend && npm install",
     "build": "npm run build:frontend",
     "build:frontend": "cd frontend && npm run build",
     "build:backend": "cd backend && npm run build",
+    "build:all": "npm run build:frontend && npm run build:backend",
+    "typecheck": "cd frontend && npm run typecheck",
+    "lint": "cd frontend && npm run lint",
+    "test": "cd frontend && npm run test",
+    "test:backend": "cd backend && npm run test",
+    "electron": "electron .",
+    "electron:dev": "NODE_ENV=development electron .",
     "pack": "electron-builder --dir",
     "dist": "electron-builder",
     "dist:mac": "npm run build && electron-builder --mac",
@@ -20,8 +31,8 @@
     "postinstall": "cd frontend && npm install && cd ../backend && npm install"
   },
   "build": {
-    "appId": "com.agentrooms.app",
-    "productName": "Agentrooms",
+    "appId": "com.claude-ops-deck.app",
+    "productName": "Claude Ops-Deck",
     "electronVersion": "32.2.7",
     "directories": {
       "output": "dist"
@@ -49,7 +60,7 @@
       "entitlementsInherit": "assets/entitlements.mac.plist"
     },
     "dmg": {
-      "title": "Agentrooms ${version}",
+      "title": "Claude Ops-Deck ${version}",
       "icon": "assets/icon.icns",
       "contents": [
         {
@@ -100,6 +111,7 @@
     }
   },
   "devDependencies": {
+    "concurrently": "^9.2.1",
     "electron": "^37.4.0",
     "electron-builder": "^25.1.8"
   }

--- a/scripts/build-windows.sh
+++ b/scripts/build-windows.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# Windows Build Script for Agentrooms
+# Windows Build Script for Claude Ops-Deck
 # This script handles the Wine dependency for cross-platform Windows builds on Linux
 
-echo "=== Agentrooms Windows Build Script ==="
+echo "=== Claude Ops-Deck Windows Build Script ==="
 echo ""
 
 # Check if Wine is installed

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -10,6 +10,7 @@ export interface ChatRequest {
   requestId: string;
   allowedTools?: string[];
   workingDirectory?: string;
+  systemPrompt?: string;
   claudeAuth?: {
     accessToken: string;
     refreshToken: string;
@@ -28,6 +29,8 @@ export interface ChatRequest {
     workingDirectory: string;
     apiEndpoint: string;
     isOrchestrator?: boolean;
+    systemPrompt?: string;
+    role?: string;
   }>;
 }
 


### PR DESCRIPTION
## Summary
- Complete rebrand from **Agentrooms** to **Claude Ops-Deck by Axiom-Labs** across all project files
- Replaces product name, author, app ID, tagline, example agent names, and theme references
- Leaves CHANGELOG.md unchanged as historical record

## Changes by unit

### Unit 1: Electron + Root Config (3 files)
- `package.json`: name, productName, description, author, appId, DMG title
- `electron/main.js`: window title, partition, error page, menu labels
- `electron/storage.js`: storage directory name

### Unit 2: Frontend Source (2 files)
- `ChatInput.tsx`: colorMap keys `readymojo-*` → `project-*`
- `useChatState.ts`: default agent fallback

### Unit 3: Backend Source + Tests (8 files)
- `backend/package.json`: name, description, keywords, bin
- `backend/app.ts`: swagger doc strings
- `backend/swagger/config.ts`: API title, contact, examples
- `backend/handlers/chat.ts`: fallback agent names
- `backend/utils/imageHandling.ts`: temp directory path
- Test files: assertions updated to match new names

### Unit 4: Documentation (5 files)
- `README.md`, `backend/README.md`, `README_BUILD.md`, `CLAUDE.md`, `STREAMING_DEPLOYMENT.md`

### Unit 5: CI/Build Scripts (2 files)
- `.github/workflows/release.yml`: artifact patterns
- `scripts/build-windows.sh`: comments and echo strings

## Replacement mapping
| Old | New |
|-----|-----|
| `Agentrooms` | `Claude Ops-Deck` |
| `agentrooms` | `claude-ops-deck` |
| `Agentrooms Team` / `sugyan` | `Axiom-Labs` |
| `com.agentrooms.app` | `com.axiom-labs.claude-ops-deck` |
| `Multi-Agent Workspace` | `AI Agent Mission Control` |
| `ReadyMojo Admin/API/Web` | `Project Admin/API/Web` |
| `readymojo-*` | `project-*` |

## Test plan
- [x] Frontend builds successfully (`npm run build`)
- [x] Backend tests pass (same pre-existing failures, none caused by rebrand)
- [x] Grep sweep confirms no remaining `agentrooms` or `readymojo` references (excluding internal variable names and CHANGELOG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)